### PR TITLE
feat:category api 추가

### DIFF
--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/category/controller/CategoryController.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/category/controller/CategoryController.java
@@ -3,7 +3,7 @@ package com.daebbang.daebbangapi.domain.category.controller;
 import com.daebbang.daebbangapi.domain.category.dto.response.CategoryList;
 import com.daebbang.daebbangcommon.dto.response.CommonResponse;
 import com.daebbang.daebbangcommon.success.CommonSuccessCode;
-import com.daebbang.daebbangcore.domain.category.entity.Category;
+import com.daebbang.daebbangcore.domain.category.dto.CategoryHierarchy;
 import com.daebbang.daebbangcore.domain.category.service.CategoryService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,17 +20,8 @@ public class CategoryController {
 
     @GetMapping
     public CommonResponse<List<CategoryList>> getCategories() {
-        List<Category> all = categoryService.getAllCategories();
-
-        List<Category> superCategories = all.stream()
-            .filter(c -> c.getSuperCategory() == null)
-            .toList();
-
-        List<Category> children = all.stream()
-            .filter(c -> c.getSuperCategory() != null)
-            .toList();
-
+        CategoryHierarchy hierarchy = categoryService.getCategoryHierarchy();
         return CommonResponse.success(CommonSuccessCode.SELECT_SUCCESS,
-            CategoryList.from(superCategories, children));
+            CategoryList.from(hierarchy.superCategories(), hierarchy.children()));
     }
 }

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/category/controller/CategoryController.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/category/controller/CategoryController.java
@@ -1,0 +1,36 @@
+package com.daebbang.daebbangapi.domain.category.controller;
+
+import com.daebbang.daebbangapi.domain.category.dto.response.CategoryList;
+import com.daebbang.daebbangcommon.dto.response.CommonResponse;
+import com.daebbang.daebbangcommon.success.CommonSuccessCode;
+import com.daebbang.daebbangcore.domain.category.entity.Category;
+import com.daebbang.daebbangcore.domain.category.service.CategoryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public CommonResponse<List<CategoryList>> getCategories() {
+        List<Category> all = categoryService.getAllCategories();
+
+        List<Category> superCategories = all.stream()
+            .filter(c -> c.getSuperCategory() == null)
+            .toList();
+
+        List<Category> children = all.stream()
+            .filter(c -> c.getSuperCategory() != null)
+            .toList();
+
+        return CommonResponse.success(CommonSuccessCode.SELECT_SUCCESS,
+            CategoryList.from(superCategories, children));
+    }
+}

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/category/dto/response/CategoryList.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/category/dto/response/CategoryList.java
@@ -1,0 +1,28 @@
+package com.daebbang.daebbangapi.domain.category.dto.response;
+
+import com.daebbang.daebbangcore.domain.category.entity.Category;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public record CategoryList(
+    Long id,
+    String categoryName,
+    List<CategoryList> children
+) {
+    public static List<CategoryList> from(List<Category> superCategories, List<Category> allChildren) {
+        Map<Long, List<Category>> childrenByParentId = allChildren.stream()
+            .collect(Collectors.groupingBy(c -> c.getSuperCategory().getId()));
+
+        return superCategories.stream()
+            .map(c -> new CategoryList(
+                c.getId(),
+                c.getCategoryName(),
+                childrenByParentId.getOrDefault(c.getId(), List.of())
+                    .stream()
+                    .map(child -> new CategoryList(child.getId(), child.getCategoryName(), List.of()))
+                    .toList()
+            ))
+            .toList();
+    }
+}

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/security/dto/SecurityConstants.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/security/dto/SecurityConstants.java
@@ -4,7 +4,8 @@ public abstract class SecurityConstants {
     public static final String[] PUBLIC_GET_URI = {
         "/v1/users/find/**",
         "/v1/users/check/**",
-        "/v1/products/**"
+        "/v1/products/**",
+        "/v1/categories/**"
     };
 
     public static final String[] PUBLIC_POST_URI = {

--- a/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -152,6 +152,42 @@ paths:
                 cart/delete-carts:
                   value: "{\"success\":true,\"status\":200,\"message\":\"장바구니 삭제에\
                     \ 성공하였습니다.\",\"data\":null}"
+  /v1/categories:
+    get:
+      tags:
+      - Category
+      summary: 전체 카테고리 계층 조회 - 빈 목록
+      description: 등록된 카테고리가 없는 경우 빈 배열을 반환합니다.
+      operationId: categories/
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryListResponse'
+              examples:
+                categories/list-empty:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"조회에 성공하였습\
+                    니다.\",\"data\":[]}"
+                categories/list-no-children:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"조회에 성공하였습\
+                    니다.\",\"data\":[{\"id\":1,\"categoryName\":\"상의\",\"children\"\
+                    :[]}]}"
+                categories/list-success:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"조회에 성공하였습\
+                    니다.\",\"data\":[{\"id\":1,\"categoryName\":\"상의\",\"children\"\
+                    :[{\"id\":3,\"categoryName\":\"반팔\",\"children\":[]},{\"id\":4,\"\
+                    categoryName\":\"긴팔\",\"children\":[]}]},{\"id\":2,\"categoryName\"\
+                    :\"하의\",\"children\":[{\"id\":5,\"categoryName\":\"청바지\",\"children\"\
+                    :[]}]}]}"
+                categories/super-list-empty:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"조회에 성공하였습\
+                    니다.\",\"data\":[]}"
+                categories/super-list-success:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"조회에 성공하였습\
+                    니다.\",\"data\":[{\"id\":null,\"categoryName\":\"상의\"},{\"id\"\
+                    :null,\"categoryName\":\"하의\"}]}"
   /v1/logout:
     delete:
       tags:
@@ -315,6 +351,47 @@ paths:
                 cart/update-cart-not-found:
                   value: "{\"success\":false,\"status\":404,\"message\":\"존재하지 않는\
                     \ 카트 번호입니다.\",\"data\":null}"
+  /v1/categories/{categoryId}:
+    get:
+      tags:
+      - Category
+      summary: 하위 카테고리 목록 조회 - 빈 목록
+      description: 하위 카테고리가 없는 경우 빈 배열을 반환합니다.
+      operationId: categories/child-list-
+      parameters:
+      - name: categoryId
+        in: path
+        description: 상위 카테고리 ID
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChildCategoryListResponse'
+              examples:
+                categories/child-list-empty:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"조회에 성공하였습\
+                    니다.\",\"data\":[]}"
+                categories/child-list-success:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"조회에 성공하였습\
+                    니다.\",\"data\":[{\"id\":null,\"categoryName\":\"반팔\"},{\"id\"\
+                    :null,\"categoryName\":\"긴팔\"},{\"id\":null,\"categoryName\":\"\
+                    니트\"}]}"
+        "404":
+          description: "404"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                categories/child-list-not-found:
+                  value: "{\"success\":false,\"status\":404,\"message\":\"존재하지 않는\
+                    \ 카테고리입니다.\",\"data\":null}"
   /v1/products/new:
     get:
       tags:
@@ -1338,6 +1415,31 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
+    ChildCategoryListResponse:
+      title: ChildCategoryListResponse
+      type: object
+      properties:
+        data:
+          type: array
+          description: 하위 카테고리 목록
+          items:
+            type: object
+            properties:
+              id:
+                type: object
+                description: 카테고리 ID
+              categoryName:
+                type: string
+                description: 카테고리명
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 응답 메시지
+        status:
+          type: number
+          description: HTTP 상태 코드
     ProductDetailResponse:
       title: ProductDetailResponse
       type: object
@@ -1462,6 +1564,52 @@ components:
               type: string
               description: 발송된 인증번호 (6자리)
           description: 발송 결과
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 응답 메시지
+        status:
+          type: number
+          description: HTTP 상태 코드
+    CategoryListResponse:
+      title: CategoryListResponse
+      type: object
+      properties:
+        data:
+          type: array
+          description: 상위 카테고리 목록
+          items:
+            type: object
+            properties:
+              children:
+                type: array
+                description: 하위 카테고리 목록
+                items:
+                  type: object
+                  properties:
+                    children:
+                      type: array
+                      description: "하위의 하위 카테고리 (현재 미사용, 빈 배열)"
+                      items:
+                        oneOf:
+                        - type: object
+                        - type: boolean
+                        - type: string
+                        - type: number
+                    id:
+                      type: object
+                      description: 하위 카테고리 ID
+                    categoryName:
+                      type: string
+                      description: 하위 카테고리명
+              id:
+                type: object
+                description: 카테고리 ID
+              categoryName:
+                type: string
+                description: 카테고리명
         success:
           type: boolean
           description: 성공 여부

--- a/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -158,7 +158,7 @@ paths:
       - Category
       summary: 전체 카테고리 계층 조회 - 빈 목록
       description: 등록된 카테고리가 없는 경우 빈 배열을 반환합니다.
-      operationId: categories/
+      operationId: categories/list-
       responses:
         "200":
           description: "200"
@@ -181,13 +181,6 @@ paths:
                     categoryName\":\"긴팔\",\"children\":[]}]},{\"id\":2,\"categoryName\"\
                     :\"하의\",\"children\":[{\"id\":5,\"categoryName\":\"청바지\",\"children\"\
                     :[]}]}]}"
-                categories/super-list-empty:
-                  value: "{\"success\":true,\"status\":200,\"message\":\"조회에 성공하였습\
-                    니다.\",\"data\":[]}"
-                categories/super-list-success:
-                  value: "{\"success\":true,\"status\":200,\"message\":\"조회에 성공하였습\
-                    니다.\",\"data\":[{\"id\":null,\"categoryName\":\"상의\"},{\"id\"\
-                    :null,\"categoryName\":\"하의\"}]}"
   /v1/logout:
     delete:
       tags:
@@ -351,47 +344,6 @@ paths:
                 cart/update-cart-not-found:
                   value: "{\"success\":false,\"status\":404,\"message\":\"존재하지 않는\
                     \ 카트 번호입니다.\",\"data\":null}"
-  /v1/categories/{categoryId}:
-    get:
-      tags:
-      - Category
-      summary: 하위 카테고리 목록 조회 - 빈 목록
-      description: 하위 카테고리가 없는 경우 빈 배열을 반환합니다.
-      operationId: categories/child-list-
-      parameters:
-      - name: categoryId
-        in: path
-        description: 상위 카테고리 ID
-        required: true
-        schema:
-          type: integer
-          format: int32
-      responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ChildCategoryListResponse'
-              examples:
-                categories/child-list-empty:
-                  value: "{\"success\":true,\"status\":200,\"message\":\"조회에 성공하였습\
-                    니다.\",\"data\":[]}"
-                categories/child-list-success:
-                  value: "{\"success\":true,\"status\":200,\"message\":\"조회에 성공하였습\
-                    니다.\",\"data\":[{\"id\":null,\"categoryName\":\"반팔\"},{\"id\"\
-                    :null,\"categoryName\":\"긴팔\"},{\"id\":null,\"categoryName\":\"\
-                    니트\"}]}"
-        "404":
-          description: "404"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                categories/child-list-not-found:
-                  value: "{\"success\":false,\"status\":404,\"message\":\"존재하지 않는\
-                    \ 카테고리입니다.\",\"data\":null}"
   /v1/products/new:
     get:
       tags:
@@ -1415,31 +1367,6 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
-    ChildCategoryListResponse:
-      title: ChildCategoryListResponse
-      type: object
-      properties:
-        data:
-          type: array
-          description: 하위 카테고리 목록
-          items:
-            type: object
-            properties:
-              id:
-                type: object
-                description: 카테고리 ID
-              categoryName:
-                type: string
-                description: 카테고리명
-        success:
-          type: boolean
-          description: 성공 여부
-        message:
-          type: string
-          description: 응답 메시지
-        status:
-          type: number
-          description: HTTP 상태 코드
     ProductDetailResponse:
       title: ProductDetailResponse
       type: object
@@ -1525,6 +1452,52 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
+    CategoryListResponse:
+      title: CategoryListResponse
+      type: object
+      properties:
+        data:
+          type: array
+          description: 상위 카테고리 목록
+          items:
+            type: object
+            properties:
+              children:
+                type: array
+                description: 하위 카테고리 목록
+                items:
+                  type: object
+                  properties:
+                    children:
+                      type: array
+                      description: "하위의 하위 카테고리 (현재 미사용, 빈 배열)"
+                      items:
+                        oneOf:
+                        - type: object
+                        - type: boolean
+                        - type: string
+                        - type: number
+                    id:
+                      type: number
+                      description: 하위 카테고리 ID
+                    categoryName:
+                      type: string
+                      description: 하위 카테고리명
+              id:
+                type: number
+                description: 상위 카테고리 ID
+              categoryName:
+                type: string
+                description: 상위 카테고리명
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 응답 메시지
+        status:
+          type: number
+          description: HTTP 상태 코드
     CartSaveRequest:
       title: CartSaveRequest
       type: array
@@ -1564,52 +1537,6 @@ components:
               type: string
               description: 발송된 인증번호 (6자리)
           description: 발송 결과
-        success:
-          type: boolean
-          description: 성공 여부
-        message:
-          type: string
-          description: 응답 메시지
-        status:
-          type: number
-          description: HTTP 상태 코드
-    CategoryListResponse:
-      title: CategoryListResponse
-      type: object
-      properties:
-        data:
-          type: array
-          description: 상위 카테고리 목록
-          items:
-            type: object
-            properties:
-              children:
-                type: array
-                description: 하위 카테고리 목록
-                items:
-                  type: object
-                  properties:
-                    children:
-                      type: array
-                      description: "하위의 하위 카테고리 (현재 미사용, 빈 배열)"
-                      items:
-                        oneOf:
-                        - type: object
-                        - type: boolean
-                        - type: string
-                        - type: number
-                    id:
-                      type: object
-                      description: 하위 카테고리 ID
-                    categoryName:
-                      type: string
-                      description: 하위 카테고리명
-              id:
-                type: object
-                description: 카테고리 ID
-              categoryName:
-                type: string
-                description: 카테고리명
         success:
           type: boolean
           description: 성공 여부

--- a/daebbang-api/src/test/java/com/daebbang/daebbangapi/config/TestSecurityConfig.java
+++ b/daebbang-api/src/test/java/com/daebbang/daebbangapi/config/TestSecurityConfig.java
@@ -40,6 +40,7 @@ public class TestSecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/v1/users/check/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/v1/tokens/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/v1/products/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/v1/categories/**").permitAll()
                 .anyRequest().authenticated()
             )
             .exceptionHandling(ex -> ex

--- a/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/category/controller/CategoryControllerTest.java
+++ b/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/category/controller/CategoryControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.daebbang.daebbangapi.config.PasswordConfig;
 import com.daebbang.daebbangapi.config.TestSecurityConfig;
+import com.daebbang.daebbangcore.domain.category.dto.CategoryHierarchy;
 import com.daebbang.daebbangcore.domain.category.entity.Category;
 import com.daebbang.daebbangcore.domain.category.service.CategoryService;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -65,29 +66,31 @@ class CategoryControllerTest {
         // given
         Category 상의 = mockSuperCategory(1L, "상의");
         Category 하의 = mockSuperCategory(2L, "하의");
-
         Category 반팔 = mockChildCategory(상의, 3L, "반팔");
         Category 긴팔 = mockChildCategory(상의, 4L, "긴팔");
         Category 청바지 = mockChildCategory(하의, 5L, "청바지");
 
-        given(categoryService.getAllCategories()).willReturn(List.of(상의, 하의, 반팔, 긴팔, 청바지));
+        given(categoryService.getCategoryHierarchy())
+            .willReturn(new CategoryHierarchy(List.of(상의, 하의), List.of(반팔, 긴팔, 청바지)));
 
         // when & then
-        mockMvc.perform(get(BASE_URL)
-                .accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get(BASE_URL).accept(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.status").value(200))
-            .andExpect(jsonPath("$.data").isArray())
             .andExpect(jsonPath("$.data.length()").value(2))
+            .andExpect(jsonPath("$.data[0].id").value(1))
             .andExpect(jsonPath("$.data[0].categoryName").value("상의"))
-            .andExpect(jsonPath("$.data[0].children").isArray())
             .andExpect(jsonPath("$.data[0].children.length()").value(2))
+            .andExpect(jsonPath("$.data[0].children[0].id").value(3))
             .andExpect(jsonPath("$.data[0].children[0].categoryName").value("반팔"))
+            .andExpect(jsonPath("$.data[0].children[1].id").value(4))
             .andExpect(jsonPath("$.data[0].children[1].categoryName").value("긴팔"))
+            .andExpect(jsonPath("$.data[1].id").value(2))
             .andExpect(jsonPath("$.data[1].categoryName").value("하의"))
             .andExpect(jsonPath("$.data[1].children.length()").value(1))
+            .andExpect(jsonPath("$.data[1].children[0].id").value(5))
             .andExpect(jsonPath("$.data[1].children[0].categoryName").value("청바지"))
             .andDo(document("categories/list-success",
                 resource(ResourceSnippetParameters.builder()
@@ -100,10 +103,10 @@ class CategoryControllerTest {
                         fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                         fieldWithPath("data").type(JsonFieldType.ARRAY).description("상위 카테고리 목록"),
-                        fieldWithPath("data[].id").type(JsonFieldType.VARIES).description("상위 카테고리 ID"),
+                        fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("상위 카테고리 ID"),
                         fieldWithPath("data[].categoryName").type(JsonFieldType.STRING).description("상위 카테고리명"),
                         fieldWithPath("data[].children").type(JsonFieldType.ARRAY).description("하위 카테고리 목록"),
-                        fieldWithPath("data[].children[].id").type(JsonFieldType.VARIES).description("하위 카테고리 ID"),
+                        fieldWithPath("data[].children[].id").type(JsonFieldType.NUMBER).description("하위 카테고리 ID"),
                         fieldWithPath("data[].children[].categoryName").type(JsonFieldType.STRING).description("하위 카테고리명"),
                         fieldWithPath("data[].children[].children").type(JsonFieldType.ARRAY).description("하위의 하위 카테고리 (현재 미사용, 빈 배열)")
                     )
@@ -115,11 +118,11 @@ class CategoryControllerTest {
     @DisplayName("GET /v1/categories - 등록된 카테고리가 없는 경우 빈 목록 반환")
     void getCategories_empty() throws Exception {
         // given
-        given(categoryService.getAllCategories()).willReturn(List.of());
+        given(categoryService.getCategoryHierarchy())
+            .willReturn(new CategoryHierarchy(List.of(), List.of()));
 
         // when & then
-        mockMvc.perform(get(BASE_URL)
-                .accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get(BASE_URL).accept(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
@@ -147,15 +150,15 @@ class CategoryControllerTest {
         // given
         Category 상의 = mockSuperCategory(1L, "상의");
 
-        given(categoryService.getAllCategories()).willReturn(List.of(상의));
+        given(categoryService.getCategoryHierarchy())
+            .willReturn(new CategoryHierarchy(List.of(상의), List.of()));
 
         // when & then
-        mockMvc.perform(get(BASE_URL)
-                .accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get(BASE_URL).accept(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.length()").value(1))
+            .andExpect(jsonPath("$.data[0].id").value(1))
             .andExpect(jsonPath("$.data[0].categoryName").value("상의"))
             .andExpect(jsonPath("$.data[0].children").isArray())
             .andExpect(jsonPath("$.data[0].children").isEmpty())
@@ -170,11 +173,31 @@ class CategoryControllerTest {
                         fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                         fieldWithPath("data").type(JsonFieldType.ARRAY).description("상위 카테고리 목록"),
-                        fieldWithPath("data[].id").type(JsonFieldType.VARIES).description("상위 카테고리 ID"),
+                        fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("상위 카테고리 ID"),
                         fieldWithPath("data[].categoryName").type(JsonFieldType.STRING).description("상위 카테고리명"),
                         fieldWithPath("data[].children").type(JsonFieldType.ARRAY).description("하위 카테고리 목록 (빈 배열)")
                     )
                     .build()
                 )));
+    }
+
+    @Test
+    @DisplayName("GET /v1/categories - 여러 상위 카테고리 중 일부만 하위 카테고리가 있는 경우")
+    void getCategories_mixedChildren() throws Exception {
+        // given
+        Category 상의 = mockSuperCategory(1L, "상의");
+        Category 악세서리 = mockSuperCategory(2L, "악세서리");  // 하위 카테고리 없음
+        Category 반팔 = mockChildCategory(상의, 3L, "반팔");
+
+        given(categoryService.getCategoryHierarchy())
+            .willReturn(new CategoryHierarchy(List.of(상의, 악세서리), List.of(반팔)));
+
+        // when & then
+        mockMvc.perform(get(BASE_URL).accept(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.length()").value(2))
+            .andExpect(jsonPath("$.data[0].children.length()").value(1))
+            .andExpect(jsonPath("$.data[1].children").isEmpty());
     }
 }

--- a/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/category/controller/CategoryControllerTest.java
+++ b/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/category/controller/CategoryControllerTest.java
@@ -1,0 +1,180 @@
+package com.daebbang.daebbangapi.domain.category.controller;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.daebbang.daebbangapi.config.PasswordConfig;
+import com.daebbang.daebbangapi.config.TestSecurityConfig;
+import com.daebbang.daebbangcore.domain.category.entity.Category;
+import com.daebbang.daebbangcore.domain.category.service.CategoryService;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = CategoryController.class)
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+@Import({PasswordConfig.class, TestSecurityConfig.class})
+class CategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CategoryService categoryService;
+
+    private static final String BASE_URL = "/v1/categories";
+
+    private Category mockSuperCategory(Long id, String name) {
+        Category category = mock(Category.class);
+        given(category.getId()).willReturn(id);
+        given(category.getCategoryName()).willReturn(name);
+        given(category.getSuperCategory()).willReturn(null);
+        return category;
+    }
+
+    private Category mockChildCategory(Category parent, Long id, String name) {
+        Category category = mock(Category.class);
+        given(category.getId()).willReturn(id);
+        given(category.getCategoryName()).willReturn(name);
+        given(category.getSuperCategory()).willReturn(parent);
+        return category;
+    }
+
+    @Test
+    @DisplayName("GET /v1/categories - 전체 카테고리 계층 구조 조회 성공")
+    void getCategories_success() throws Exception {
+        // given
+        Category 상의 = mockSuperCategory(1L, "상의");
+        Category 하의 = mockSuperCategory(2L, "하의");
+
+        Category 반팔 = mockChildCategory(상의, 3L, "반팔");
+        Category 긴팔 = mockChildCategory(상의, 4L, "긴팔");
+        Category 청바지 = mockChildCategory(하의, 5L, "청바지");
+
+        given(categoryService.getAllCategories()).willReturn(List.of(상의, 하의, 반팔, 긴팔, 청바지));
+
+        // when & then
+        mockMvc.perform(get(BASE_URL)
+                .accept(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.data").isArray())
+            .andExpect(jsonPath("$.data.length()").value(2))
+            .andExpect(jsonPath("$.data[0].categoryName").value("상의"))
+            .andExpect(jsonPath("$.data[0].children").isArray())
+            .andExpect(jsonPath("$.data[0].children.length()").value(2))
+            .andExpect(jsonPath("$.data[0].children[0].categoryName").value("반팔"))
+            .andExpect(jsonPath("$.data[0].children[1].categoryName").value("긴팔"))
+            .andExpect(jsonPath("$.data[1].categoryName").value("하의"))
+            .andExpect(jsonPath("$.data[1].children.length()").value(1))
+            .andExpect(jsonPath("$.data[1].children[0].categoryName").value("청바지"))
+            .andDo(document("categories/list-success",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Category")
+                    .summary("전체 카테고리 계층 조회")
+                    .description("상위 카테고리와 하위 카테고리를 계층 구조로 반환합니다. 단일 API 호출로 전체 카테고리 트리를 반환합니다.")
+                    .responseSchema(Schema.schema("CategoryListResponse"))
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.ARRAY).description("상위 카테고리 목록"),
+                        fieldWithPath("data[].id").type(JsonFieldType.VARIES).description("상위 카테고리 ID"),
+                        fieldWithPath("data[].categoryName").type(JsonFieldType.STRING).description("상위 카테고리명"),
+                        fieldWithPath("data[].children").type(JsonFieldType.ARRAY).description("하위 카테고리 목록"),
+                        fieldWithPath("data[].children[].id").type(JsonFieldType.VARIES).description("하위 카테고리 ID"),
+                        fieldWithPath("data[].children[].categoryName").type(JsonFieldType.STRING).description("하위 카테고리명"),
+                        fieldWithPath("data[].children[].children").type(JsonFieldType.ARRAY).description("하위의 하위 카테고리 (현재 미사용, 빈 배열)")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("GET /v1/categories - 등록된 카테고리가 없는 경우 빈 목록 반환")
+    void getCategories_empty() throws Exception {
+        // given
+        given(categoryService.getAllCategories()).willReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get(BASE_URL)
+                .accept(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray())
+            .andExpect(jsonPath("$.data").isEmpty())
+            .andDo(document("categories/list-empty",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Category")
+                    .summary("전체 카테고리 계층 조회 - 빈 목록")
+                    .description("등록된 카테고리가 없는 경우 빈 배열을 반환합니다.")
+                    .responseSchema(Schema.schema("CategoryListResponse"))
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.ARRAY).description("카테고리 목록 (빈 배열)")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("GET /v1/categories - 하위 카테고리가 없는 상위 카테고리는 children 빈 배열로 반환")
+    void getCategories_superCategoryWithNoChildren() throws Exception {
+        // given
+        Category 상의 = mockSuperCategory(1L, "상의");
+
+        given(categoryService.getAllCategories()).willReturn(List.of(상의));
+
+        // when & then
+        mockMvc.perform(get(BASE_URL)
+                .accept(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.length()").value(1))
+            .andExpect(jsonPath("$.data[0].categoryName").value("상의"))
+            .andExpect(jsonPath("$.data[0].children").isArray())
+            .andExpect(jsonPath("$.data[0].children").isEmpty())
+            .andDo(document("categories/list-no-children",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Category")
+                    .summary("전체 카테고리 계층 조회 - 하위 카테고리 없음")
+                    .description("하위 카테고리가 없는 상위 카테고리는 children을 빈 배열로 반환합니다.")
+                    .responseSchema(Schema.schema("CategoryListResponse"))
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.ARRAY).description("상위 카테고리 목록"),
+                        fieldWithPath("data[].id").type(JsonFieldType.VARIES).description("상위 카테고리 ID"),
+                        fieldWithPath("data[].categoryName").type(JsonFieldType.STRING).description("상위 카테고리명"),
+                        fieldWithPath("data[].children").type(JsonFieldType.ARRAY).description("하위 카테고리 목록 (빈 배열)")
+                    )
+                    .build()
+                )));
+    }
+}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/cart/repository/CartRepository.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/cart/repository/CartRepository.java
@@ -36,14 +36,20 @@ public interface CartRepository extends JpaRepository<@NonNull Carts, @NonNull L
     WHERE c.user.id = :userId
       AND c.productDetail.id IN :productDetailIds
     """)
-    List<Carts> findByUserIdAndProductDetailIdIn(Long userId, List<Long> productDetailIds);
+    List<Carts> findByUserIdAndProductDetailIdIn(
+        @Param("userId") Long userId,
+        @Param("productDetailIds") List<Long> productDetailIds
+    );
 
     @Query("""
     SELECT c FROM Carts c
     WHERE c.id = :cartId
       AND c.user.id = :userId
     """)
-    Optional<Carts> findByIdAndUserId(Long cartId, Long userId);
+    Optional<Carts> findByIdAndUserId(
+        @Param("cartId") Long cartId,
+        @Param("userId") Long userId
+    );
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
@@ -52,7 +58,10 @@ public interface CartRepository extends JpaRepository<@NonNull Carts, @NonNull L
     WHERE c.id IN :cartIds
       AND c.user.id = :userId
     """)
-    void deleteCartsByCartIds(List<Long> cartIds, Long userId);
+    void deleteCartsByCartIds(
+        @Param("cartIds") List<Long> cartIds,
+        @Param("userId") Long userId
+    );
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
@@ -60,5 +69,5 @@ public interface CartRepository extends JpaRepository<@NonNull Carts, @NonNull L
     FROM Carts c
     WHERE c.user.id = :userId
     """)
-    void deleteAllCartsByUserId(Long userId);
+    void deleteAllCartsByUserId(@Param("userId") Long userId);
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/dto/CategoryHierarchy.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/dto/CategoryHierarchy.java
@@ -1,0 +1,16 @@
+package com.daebbang.daebbangcore.domain.category.dto;
+
+import com.daebbang.daebbangcore.domain.category.entity.Category;
+import java.util.List;
+
+public record CategoryHierarchy(
+    List<Category> superCategories,
+    List<Category> children
+) {
+    public static CategoryHierarchy from(List<Category> all) {
+        return new CategoryHierarchy(
+            all.stream().filter(c -> c.getSuperCategory() == null).toList(),
+            all.stream().filter(c -> c.getSuperCategory() != null).toList()
+        );
+    }
+}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/repository/CategoryRepository.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/repository/CategoryRepository.java
@@ -24,6 +24,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     @Query("""
     SELECT c
     FROM Category c
+    LEFT JOIN FETCH c.superCategory
     WHERE c.deletedAt IS NULL
     """)
     List<Category> findAllCategories();

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/repository/CategoryRepository.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/repository/CategoryRepository.java
@@ -1,10 +1,12 @@
 package com.daebbang.daebbangcore.domain.category.repository;
 
 import com.daebbang.daebbangcore.domain.category.entity.Category;
+import java.util.List;
 import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @NullMarked
@@ -17,5 +19,12 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     WHERE c.deletedAt is NULL
       AND c.id = :id
     """)
-    Optional<Category> findCategoryById(Long id);
+    Optional<Category> findCategoryById(@Param("id") Long id);
+
+    @Query("""
+    SELECT c
+    FROM Category c
+    WHERE c.deletedAt IS NULL
+    """)
+    List<Category> findAllCategories();
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/service/CategoryService.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/service/CategoryService.java
@@ -1,9 +1,9 @@
 package com.daebbang.daebbangcore.domain.category.service;
 
+import com.daebbang.daebbangcore.domain.category.dto.CategoryHierarchy;
 import com.daebbang.daebbangcore.domain.category.entity.Category;
-import java.util.List;
 
 public interface CategoryService {
     Category getActiveCategoryById(Long id);
-    List<Category> getAllCategories();
+    CategoryHierarchy getCategoryHierarchy();
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/service/CategoryService.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/service/CategoryService.java
@@ -1,7 +1,9 @@
 package com.daebbang.daebbangcore.domain.category.service;
 
 import com.daebbang.daebbangcore.domain.category.entity.Category;
+import java.util.List;
 
 public interface CategoryService {
     Category getActiveCategoryById(Long id);
+    List<Category> getAllCategories();
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/service/impl/CategoryServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/service/impl/CategoryServiceImpl.java
@@ -5,6 +5,7 @@ import com.daebbang.daebbangcommon.error.UserErrorCode;
 import com.daebbang.daebbangcore.domain.category.entity.Category;
 import com.daebbang.daebbangcore.domain.category.repository.CategoryRepository;
 import com.daebbang.daebbangcore.domain.category.service.CategoryService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,11 +19,12 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     public Category getActiveCategoryById(Long id) {
-        return getCategoryById(id);
-    }
-
-    private Category getCategoryById(Long id) {
         return categoryRepository.findCategoryById(id)
             .orElseThrow(() -> new BusinessException(UserErrorCode.CATEGORY_NOT_FOUND));
+    }
+
+    @Override
+    public List<Category> getAllCategories() {
+        return categoryRepository.findAllCategories();
     }
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/service/impl/CategoryServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/category/service/impl/CategoryServiceImpl.java
@@ -2,10 +2,10 @@ package com.daebbang.daebbangcore.domain.category.service.impl;
 
 import com.daebbang.daebbangcommon.error.BusinessException;
 import com.daebbang.daebbangcommon.error.UserErrorCode;
+import com.daebbang.daebbangcore.domain.category.dto.CategoryHierarchy;
 import com.daebbang.daebbangcore.domain.category.entity.Category;
 import com.daebbang.daebbangcore.domain.category.repository.CategoryRepository;
 import com.daebbang.daebbangcore.domain.category.service.CategoryService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +24,7 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
-    public List<Category> getAllCategories() {
-        return categoryRepository.findAllCategories();
+    public CategoryHierarchy getCategoryHierarchy() {
+        return CategoryHierarchy.from(categoryRepository.findAllCategories());
     }
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/user/repository/UsersRepository.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/user/repository/UsersRepository.java
@@ -8,10 +8,11 @@ import java.util.Optional;
 import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UsersRepository extends JpaRepository<@NonNull Users,@NonNull Long> {
+public interface UsersRepository extends JpaRepository<@NonNull Users, @NonNull Long> {
 
     @Query("""
     SELECT COUNT(u) > 0
@@ -19,7 +20,10 @@ public interface UsersRepository extends JpaRepository<@NonNull Users,@NonNull L
     WHERE u.phoneNumber = :phoneNumber
       AND u.status != :excludeStatus
     """)
-    boolean existsPhoneNumber(String phoneNumber, UserStatus excludeStatus);
+    boolean existsPhoneNumber(
+        @Param("phoneNumber") String phoneNumber,
+        @Param("excludeStatus") UserStatus excludeStatus
+    );
 
     @Query("""
     SELECT COUNT(u) > 0
@@ -27,7 +31,10 @@ public interface UsersRepository extends JpaRepository<@NonNull Users,@NonNull L
     WHERE u.loginId = :loginId
       AND u.status != :excludeStatus
     """)
-    boolean existsActiveUser(String loginId, UserStatus excludeStatus);
+    boolean existsActiveUser(
+        @Param("loginId") String loginId,
+        @Param("excludeStatus") UserStatus excludeStatus
+    );
 
     @Query("""
     SELECT COUNT(u) > 0
@@ -37,7 +44,12 @@ public interface UsersRepository extends JpaRepository<@NonNull Users,@NonNull L
       AND u.email = :email
       AND u.status != :excludeStatus
     """)
-    boolean existsActiveUser(String username, String loginId, String email, UserStatus excludeStatus);
+    boolean existsActiveUser(
+        @Param("username") String username,
+        @Param("loginId") String loginId,
+        @Param("email") String email,
+        @Param("excludeStatus") UserStatus excludeStatus
+    );
 
     @Query("""
     SELECT u
@@ -46,7 +58,11 @@ public interface UsersRepository extends JpaRepository<@NonNull Users,@NonNull L
       AND u.status != :excludeStatus
       AND u.provider = :provider
     """)
-    Optional<Users> findActiveUserByLoginIdAndProvider(String loginId, UserStatus excludeStatus, Provider provider);
+    Optional<Users> findActiveUserByLoginIdAndProvider(
+        @Param("loginId") String loginId,
+        @Param("excludeStatus") UserStatus excludeStatus,
+        @Param("provider") Provider provider
+    );
 
     @Query("""
     SELECT u
@@ -54,7 +70,10 @@ public interface UsersRepository extends JpaRepository<@NonNull Users,@NonNull L
     WHERE u.status != :excludeStatus
       AND u.loginId = :loginId
     """)
-    Optional<Users> findActiveUserByLoginId(String loginId, UserStatus excludeStatus);
+    Optional<Users> findActiveUserByLoginId(
+        @Param("loginId") String loginId,
+        @Param("excludeStatus") UserStatus excludeStatus
+    );
 
     @Query("""
     SELECT u
@@ -63,5 +82,9 @@ public interface UsersRepository extends JpaRepository<@NonNull Users,@NonNull L
       AND u.email = :email
       AND u.status != :excludeStatus
     """)
-    List<Users> findActiveUserIdsByUsernameAndEmail(String username, String email, UserStatus excludeStatus);
+    List<Users> findActiveUserIdsByUsernameAndEmail(
+        @Param("username") String username,
+        @Param("email") String email,
+        @Param("excludeStatus") UserStatus excludeStatus
+    );
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/wish/repository/WishListRepository.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/wish/repository/WishListRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,8 +14,11 @@ public interface WishListRepository extends JpaRepository<@NonNull WishList, @No
     @Query("""
     SELECT w
     FROM WishList w
-    WHERE w.user.id =: userId
-      AND w.product.id =: productId
+    WHERE w.user.id = :userId
+      AND w.product.id = :productId
     """)
-    Optional<WishList> findWishListByUserIdAndProductId(Long userId, Long productId);
+    Optional<WishList> findWishListByUserIdAndProductId(
+        @Param("userId") Long userId,
+        @Param("productId") Long productId
+    );
 }


### PR DESCRIPTION
## 💻 작업 내용
<!-- 작업한 내용을 작성해주세요. -->
그 외 repository JPQL param 어노테이션 추가
category api test 및 swagger 문서화 작업 추가
<br></br>
## 💬 추가 전달 사항
<!-- 추가로 전달할 내용이 있다면 적어주세요. -->

<br></br>
## 💁‍♂️ 관련 Issues
<!-- 관련된 이슈 번호를 작성해 주세요. -->
#79 close

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 상품 카테고리 계층 조회 API 추가: 상위/하위 구조로 카테고리 목록 반환 및 계층형 응답 제공

* **Tests**
  * 카테고리 조회 관련 다양한 시나리오 단위 테스트 및 API 문서화용 테스트 추가

* **Chores**
  * API 문서(오픈API)에 카테고리 엔드포인트 명세 추가 및 공개 GET 경로 허용
  * JPA 리포지토리 쿼리 파라미터 바인딩 개선 (가독성/명시성 향상)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->