### PR TITLE
feat: 주문 api 추가

### DIFF
--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/controller/OrderController.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/controller/OrderController.java
@@ -12,8 +12,11 @@ import com.daebbang.daebbangcommon.success.UserSuccessCode;
 import com.daebbang.daebbangcore.domain.order.dto.OrderPrepareResponse;
 import com.daebbang.daebbangcore.domain.order.service.OrderService;
 import jakarta.validation.Valid;
+import com.daebbang.daebbangcommon.error.BusinessException;
+import com.daebbang.daebbangcommon.error.UserErrorCode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -130,12 +133,15 @@ public class OrderController {
             return end.minusMonths(3);
         }
         LocalDateTime start = startDate.atStartOfDay();
+        if (start.isAfter(end)) {
+            throw new BusinessException(UserErrorCode.ORDER_DATE_RANGE_INVALID);
+        }
         return start.isBefore(oneYearAgo) ? oneYearAgo : start;
     }
 
-    private LocalDateTime resolveEndDate(LocalDate end) {
-        return end != null
-            ? end.atTime(23, 59, 59)
+    private LocalDateTime resolveEndDate(LocalDate endDate) {
+        return endDate != null
+            ? endDate.atTime(LocalTime.MAX)
             : LocalDateTime.now();
     }
 }

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/controller/OrderController.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/controller/OrderController.java
@@ -1,20 +1,35 @@
 package com.daebbang.daebbangapi.domain.order.controller;
 
+import com.daebbang.daebbangapi.domain.order.dto.request.OrderCancelRequest;
 import com.daebbang.daebbangapi.domain.order.dto.request.OrderConfirmRequest;
+import com.daebbang.daebbangapi.domain.order.dto.request.OrderPartialCancelRequest;
 import com.daebbang.daebbangapi.domain.order.dto.request.OrderPrepareRequest;
+import com.daebbang.daebbangapi.domain.order.dto.response.OrderDetailResponse;
+import com.daebbang.daebbangapi.domain.order.dto.response.OrderListItemResponse;
+import com.daebbang.daebbangapi.domain.order.dto.response.OrderStatusCountResponse;
 import com.daebbang.daebbangcommon.dto.response.CommonResponse;
 import com.daebbang.daebbangcommon.success.UserSuccessCode;
 import com.daebbang.daebbangcore.domain.order.dto.OrderPrepareResponse;
 import com.daebbang.daebbangcore.domain.order.service.OrderService;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -44,5 +59,83 @@ public class OrderController {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(CommonResponse.success(UserSuccessCode.ORDER_CONFIRMED));
+    }
+
+    @PostMapping("/{orderNumber}/cancel")
+    public ResponseEntity<@NonNull CommonResponse<Void>> cancelOrder(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable String orderNumber,
+        @Valid @RequestBody OrderCancelRequest request
+    ) {
+        orderService.cancel(request.toCommand(userId, orderNumber));
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(CommonResponse.success(UserSuccessCode.ORDER_CANCELLED));
+    }
+
+    @PostMapping("/{orderNumber}/cancel/partial")
+    public ResponseEntity<@NonNull CommonResponse<Void>> cancelOrderPartial(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable String orderNumber,
+        @Valid @RequestBody OrderPartialCancelRequest request
+    ) {
+        orderService.cancelPartial(request.toCommand(userId, orderNumber));
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(CommonResponse.success(UserSuccessCode.ORDER_CANCELLED));
+    }
+
+    @GetMapping
+    public ResponseEntity<@NonNull CommonResponse<Page<@NonNull OrderListItemResponse>>> getOrderList(
+        @AuthenticationPrincipal Long userId,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        LocalDateTime end = resolveEndDate(endDate);
+        LocalDateTime start = resolveStartDate(startDate, end);
+
+        Page<@NonNull OrderListItemResponse> response = orderService.getOrderList(userId, start, end, pageable)
+            .map(OrderListItemResponse::from);
+        return ResponseEntity.ok(CommonResponse.success(UserSuccessCode.ORDER_LIST_RETRIEVED, response));
+    }
+
+    @GetMapping("/{orderNumber}")
+    public ResponseEntity<@NonNull CommonResponse<OrderDetailResponse>> getOrderDetail(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable String orderNumber
+    ) {
+        OrderDetailResponse response = OrderDetailResponse.from(orderService.getOrderDetail(userId, orderNumber));
+        return ResponseEntity.ok(CommonResponse.success(UserSuccessCode.ORDER_DETAIL_RETRIEVED, response));
+    }
+
+    @GetMapping("/status-count")
+    public ResponseEntity<@NonNull CommonResponse<OrderStatusCountResponse>> getOrderStatusCount(
+        @AuthenticationPrincipal Long userId,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        LocalDateTime end = resolveEndDate(endDate);
+        LocalDateTime start = resolveStartDate(startDate, end);
+
+        OrderStatusCountResponse response = OrderStatusCountResponse.from(
+            orderService.getOrderStatusCount(userId, start, end)
+        );
+        return ResponseEntity.ok(CommonResponse.success(UserSuccessCode.ORDER_STATUS_COUNT_RETRIEVED, response));
+    }
+
+    private LocalDateTime resolveStartDate(LocalDate startDate, LocalDateTime end) {
+        LocalDateTime oneYearAgo = end.minusYears(1);
+        if (startDate == null) {
+            return end.minusMonths(3);
+        }
+        LocalDateTime start = startDate.atStartOfDay();
+        return start.isBefore(oneYearAgo) ? oneYearAgo : start;
+    }
+
+    private LocalDateTime resolveEndDate(LocalDate end) {
+        return end != null
+            ? end.atTime(23, 59, 59)
+            : LocalDateTime.now();
     }
 }

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderCancelRequest.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderCancelRequest.java
@@ -1,0 +1,15 @@
+package com.daebbang.daebbangapi.domain.order.dto.request;
+
+import com.daebbang.daebbangcore.domain.order.command.OrderCancelCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record OrderCancelRequest(
+    @NotBlank(message = "취소 사유를 입력해주세요.")
+    @Size(max = 200, message = "취소 사유는 200자 이하로 입력해주세요.")
+    String cancelReason
+) {
+    public OrderCancelCommand toCommand(Long userId, String orderNumber) {
+        return new OrderCancelCommand(userId, orderNumber, cancelReason);
+    }
+}

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderPartialCancelRequest.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderPartialCancelRequest.java
@@ -1,0 +1,20 @@
+package com.daebbang.daebbangapi.domain.order.dto.request;
+
+import com.daebbang.daebbangcore.domain.order.command.OrderPartialCancelCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record OrderPartialCancelRequest(
+    @NotEmpty(message = "취소할 주문 항목을 하나 이상 선택해주세요.")
+    List<Long> orderDetailIds,
+
+    @NotBlank(message = "취소 사유를 입력해주세요.")
+    @Size(max = 200, message = "취소 사유는 200자 이하로 입력해주세요.")
+    String cancelReason
+) {
+    public OrderPartialCancelCommand toCommand(Long userId, String orderNumber) {
+        return new OrderPartialCancelCommand(userId, orderNumber, orderDetailIds, cancelReason);
+    }
+}

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderPartialCancelRequest.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderPartialCancelRequest.java
@@ -3,12 +3,15 @@ package com.daebbang.daebbangapi.domain.order.dto.request;
 import com.daebbang.daebbangcore.domain.order.command.OrderPartialCancelCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record OrderPartialCancelRequest(
     @NotEmpty(message = "취소할 주문 항목을 하나 이상 선택해주세요.")
-    List<Long> orderDetailIds,
+    @Size(max = 100, message = "한 번에 최대 100개 항목까지 취소할 수 있습니다.")
+    List<@NotNull @Positive(message = "주문 항목 ID는 1 이상이어야 합니다.") Long> orderDetailIds,
 
     @NotBlank(message = "취소 사유를 입력해주세요.")
     @Size(max = 200, message = "취소 사유는 200자 이하로 입력해주세요.")

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/response/OrderDetailResponse.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/response/OrderDetailResponse.java
@@ -1,0 +1,65 @@
+package com.daebbang.daebbangapi.domain.order.dto.response;
+
+import com.daebbang.daebbangcore.domain.order.dto.OrderFullDetailResult;
+import com.daebbang.daebbangcore.domain.order.entity.OrderDetailStatus;
+import com.daebbang.daebbangcore.domain.order.entity.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderDetailResponse(
+    String orderNumber,
+    OrderStatus orderStatus,
+    LocalDateTime orderedAt,
+    int totalOriginalAmount,
+    int totalSellingAmount,
+    int shippingFee,
+    int usedPoint,
+    int paymentAmount,
+    List<OrderDetailItem> details
+) {
+    public static OrderDetailResponse from(OrderFullDetailResult result) {
+        return new OrderDetailResponse(
+            result.orderNumber(),
+            result.orderStatus(),
+            result.orderedAt(),
+            result.totalOriginalAmount(),
+            result.totalSellingAmount(),
+            result.shippingFee(),
+            result.usedPoint(),
+            result.paymentAmount(),
+            result.details().stream().map(OrderDetailItem::from).toList()
+        );
+    }
+
+    public record OrderDetailItem(
+        Long orderDetailId,
+        Long productDetailId,
+        String productName,
+        String imageUrl,
+        String color,
+        String colorCode,
+        String size,
+        int quantity,
+        int originalPrice,
+        int discountRate,
+        int discountPrice,
+        OrderDetailStatus status
+    ) {
+        public static OrderDetailItem from(OrderFullDetailResult.OrderDetailItem item) {
+            return new OrderDetailItem(
+                item.orderDetailId(),
+                item.productDetailId(),
+                item.productName(),
+                item.imageUrl(),
+                item.color(),
+                item.colorCode(),
+                item.size(),
+                item.quantity(),
+                item.originalPrice(),
+                item.discountRate(),
+                item.discountPrice(),
+                item.status()
+            );
+        }
+    }
+}

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/response/OrderListItemResponse.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/response/OrderListItemResponse.java
@@ -1,0 +1,31 @@
+package com.daebbang.daebbangapi.domain.order.dto.response;
+
+import com.daebbang.daebbangcore.domain.order.dto.OrderSummaryResult;
+import com.daebbang.daebbangcore.domain.order.entity.OrderStatus;
+import java.time.LocalDateTime;
+
+public record OrderListItemResponse(
+    String orderNumber,
+    OrderStatus orderStatus,
+    LocalDateTime orderedAt,
+    int paymentAmount,
+    int totalQuantity,
+    String representativeProductName,
+    String representativeImageUrl,
+    String representativeColor,
+    String representativeSize
+) {
+    public static OrderListItemResponse from(OrderSummaryResult result) {
+        return new OrderListItemResponse(
+            result.orderNumber(),
+            result.orderStatus(),
+            result.orderedAt(),
+            result.paymentAmount(),
+            result.totalQuantity(),
+            result.representativeProductName(),
+            result.representativeImageUrl(),
+            result.representativeColor(),
+            result.representativeSize()
+        );
+    }
+}

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/response/OrderStatusCountResponse.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/response/OrderStatusCountResponse.java
@@ -1,0 +1,19 @@
+package com.daebbang.daebbangapi.domain.order.dto.response;
+
+import com.daebbang.daebbangcore.domain.order.dto.OrderStatusCountResult;
+
+public record OrderStatusCountResponse(
+    long paid,               // 결제완료
+    long preparingDelivery,  // 배송준비중
+    long inDelivery,         // 배송중
+    long delivered           // 배송완료
+) {
+    public static OrderStatusCountResponse from(OrderStatusCountResult result) {
+        return new OrderStatusCountResponse(
+            result.paid(),
+            result.preparingDelivery(),
+            result.inDelivery(),
+            result.delivered()
+        );
+    }
+}

--- a/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -416,7 +416,7 @@ paths:
               $ref: '#/components/schemas/v1-users486549215'
             examples:
               user/withdraw-user:
-                value: _csrf=TC0lKKJDHVEZBBvim_n8xH97miJ2aCO-GG3orTu8EvAkYxF5eExGTJZ1f2c0ZS6B-NTI_E0dtxpCChSTL1zQz1qJdpQUVSQb
+                value: _csrf=RLB1kcf4plxM95XJG_76cNmEgXTeJLBxVvkyAIpS-cgMJoKwcoZFqPOclmhhk_PwKNPOQL3lrBXoHIhcMMlRZegzmPo0ErWG
       responses:
         "200":
           description: "200"

--- a/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -416,7 +416,7 @@ paths:
               $ref: '#/components/schemas/v1-users486549215'
             examples:
               user/withdraw-user:
-                value: _csrf=z_3LHFv36N9jPq8F8mDkgf8EL9hnm-OTZPgk-DkZiuwzVc---sz7LGLP3-dOWJc3lE3QtcY0AuFfrNq-U8gdnF8uso0LYf-P
+                value: _csrf=qY3Vpl-8335ER6vf8qD0zyFN-NAetZ4c5XWu6lNKgImJUbWun-_mlW6FuxxpI526xY3ArhV71egqhq4xh02fiWt-5e-xZdbM
       responses:
         "200":
           description: "200"

--- a/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -245,6 +245,66 @@ paths:
                 auth/logout-no-refresh-cookie:
                   value: "{\"success\":true,\"status\":200,\"message\":\"로그아웃에 성공하\
                     였습니다.\",\"data\":null}"
+  /v1/orders:
+    get:
+      tags:
+      - Order
+      summary: 주문 목록 조회
+      description: "로그인한 사용자의 주문 목록을 페이징하여 반환합니다.\n기본 조회 범위는 최근 3개월이며 최대 1년까지 조회 가\
+        능합니다.\nstartDate를 1년 이전으로 지정하면 자동으로 1년 전으로 보정됩니다.\n날짜 형식: yyyy-MM-dd\n"
+      operationId: order/list-
+      parameters:
+      - name: startDate
+        in: query
+        description: "조회 시작일 (yyyy-MM-dd, 기본값: 오늘 - 3개월, 최대 1년 전)"
+        required: false
+        schema:
+          type: string
+      - name: endDate
+        in: query
+        description: "조회 종료일 (yyyy-MM-dd, 기본값: 오늘)"
+        required: false
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: "페이지 번호 (0부터 시작, 기본값: 0)"
+        required: false
+        schema:
+          type: string
+      - name: size
+        in: query
+        description: "페이지 크기 (기본값: 10)"
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderListResponse'
+              examples:
+                order/list-success:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"주문 목록 조회에\
+                    \ 성공하였습니다.\",\"data\":{\"content\":[{\"orderNumber\":\"20260416-ABC1234567\"\
+                    ,\"orderStatus\":\"PAID\",\"orderedAt\":\"2026-04-16T10:00:00\"\
+                    ,\"paymentAmount\":33000,\"totalQuantity\":2,\"representativeProductName\"\
+                    :\"빵집 크루아상\",\"representativeImageUrl\":\"https://cdn.daebbang.com/img/croissant.jpg\"\
+                    ,\"representativeColor\":\"골드\",\"representativeSize\":\"M\"}],\"\
+                    empty\":false,\"first\":true,\"last\":true,\"number\":0,\"numberOfElements\"\
+                    :1,\"pageable\":{\"offset\":0,\"pageNumber\":0,\"pageSize\":10,\"\
+                    paged\":true,\"sort\":{\"empty\":true,\"sorted\":false,\"unsorted\"\
+                    :true},\"unpaged\":false},\"size\":10,\"sort\":{\"empty\":true,\"\
+                    sorted\":false,\"unsorted\":true},\"totalElements\":1,\"totalPages\"\
+                    :1}}"
+                order/list-with-date-range:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"주문 목록 조회에\
+                    \ 성공하였습니다.\",\"data\":{\"content\":[],\"empty\":true,\"first\"\
+                    :true,\"last\":true,\"number\":0,\"numberOfElements\":0,\"pageable\"\
+                    :\"INSTANCE\",\"size\":0,\"sort\":{\"empty\":true,\"sorted\":false,\"\
+                    unsorted\":true},\"totalElements\":0,\"totalPages\":1}}"
   /v1/users:
     get:
       tags:
@@ -356,7 +416,7 @@ paths:
               $ref: '#/components/schemas/v1-users486549215'
             examples:
               user/withdraw-user:
-                value: _csrf=ybyglmXXnqgDuBr-wHxJYrr1aBQi5aqXhxBdf7QUJQkB3q-4qIyX91bhrZgu2ynH91F9A4vDRSwQ15m6sCNsT4EhQz5ju5bb
+                value: _csrf=TC0lKKJDHVEZBBvim_n8xH97miJ2aCO-GG3orTu8EvAkYxF5eExGTJZ1f2c0ZS6B-NTI_E0dtxpCChSTL1zQz1qJdpQUVSQb
       responses:
         "200":
           description: "200"
@@ -536,6 +596,53 @@ paths:
                 cart/update-cart-not-found:
                   value: "{\"success\":false,\"status\":404,\"message\":\"존재하지 않는\
                     \ 카트 번호입니다.\",\"data\":null}"
+  /v1/orders/20260416-ABC1234567:
+    get:
+      tags:
+      - Order
+      summary: 주문 상세 조회
+      description: |
+        주문 번호로 해당 주문의 상세 정보를 조회합니다.
+        본인 주문만 조회 가능하며 타인의 주문 번호를 전달하면 404를 반환합니다.
+        orderDetailId를 통해 부분 취소 API에서 항목을 지정할 수 있습니다.
+      operationId: order/detail-success
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderDetailResponse'
+              examples:
+                order/detail-success:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"주문 상세 조회에\
+                    \ 성공하였습니다.\",\"data\":{\"orderNumber\":\"20260416-ABC1234567\"\
+                    ,\"orderStatus\":\"PAID\",\"orderedAt\":\"2026-04-16T10:00:00\"\
+                    ,\"totalOriginalAmount\":30000,\"totalSellingAmount\":27000,\"\
+                    shippingFee\":3000,\"usedPoint\":0,\"paymentAmount\":30000,\"\
+                    details\":[{\"orderDetailId\":10,\"productDetailId\":101,\"productName\"\
+                    :\"빵집 크루아상\",\"imageUrl\":\"https://cdn.daebbang.com/img/croissant.jpg\"\
+                    ,\"color\":\"골드\",\"colorCode\":\"#FFD700\",\"size\":\"M\",\"\
+                    quantity\":2,\"originalPrice\":15000,\"discountRate\":10,\"discountPrice\"\
+                    :13500,\"status\":\"NORMAL\"}]}}"
+  /v1/orders/20260416-NOTEXIST00:
+    get:
+      tags:
+      - Order
+      summary: 주문 상세 조회 - 주문 없음
+      description: 존재하지 않거나 본인 주문이 아닌 경우 404를 반환합니다.
+      operationId: order/detail-not-found
+      responses:
+        "404":
+          description: "404"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                order/detail-not-found:
+                  value: "{\"success\":false,\"status\":404,\"message\":\"존재하지 않는\
+                    \ 주문입니다.\",\"data\":null}"
   /v1/orders/confirm:
     post:
       tags:
@@ -744,6 +851,45 @@ paths:
                   value: "{\"success\":true,\"status\":200,\"message\":\"주문이 생성되었습\
                     니다.\",\"data\":{\"orderNumber\":\"20260416-GHI1357924\",\"paymentAmount\"\
                     :30000}}"
+  /v1/orders/status-count:
+    get:
+      tags:
+      - Order
+      summary: 배송 현황 건수 조회
+      description: |
+        마이페이지 상단에 표시할 배송 현황 건수를 반환합니다.
+        결제완료 / 배송준비중 / 배송중 / 배송완료 4가지 상태별 건수를 제공합니다.
+        날짜 범위를 지정하지 않으면 기본 3개월 기준으로 집계하며 최대 1년까지 조회 가능합니다.
+      operationId: order/status-count-
+      parameters:
+      - name: startDate
+        in: query
+        description: "조회 시작일 (yyyy-MM-dd, 기본값: 오늘 - 3개월)"
+        required: false
+        schema:
+          type: string
+      - name: endDate
+        in: query
+        description: "조회 종료일 (yyyy-MM-dd, 기본값: 오늘)"
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderStatusCountResponse'
+              examples:
+                order/status-count-success:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"배송 현황 건수\
+                    \ 조회에 성공하였습니다.\",\"data\":{\"paid\":2,\"preparingDelivery\":1,\"\
+                    inDelivery\":3,\"delivered\":1}}"
+                order/status-count-with-date-range:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"배송 현황 건수\
+                    \ 조회에 성공하였습니다.\",\"data\":{\"paid\":0,\"preparingDelivery\":0,\"\
+                    inDelivery\":0,\"delivered\":0}}"
   /v1/products/new:
     get:
       tags:
@@ -1101,6 +1247,88 @@ paths:
                 wish-lists/delete-02-all:
                   value: "{\"success\":true,\"status\":200,\"message\":\"위시리스트 삭제에\
                     \ 성공하였습니다.\",\"data\":null}"
+  /v1/orders/20260416-ABC1234567/cancel:
+    post:
+      tags:
+      - Order
+      summary: 주문 전체 취소 - 취소 사유 누락
+      description: 취소 사유가 빈 문자열이면 400 Bad Request를 반환합니다.
+      operationId: order/cancel-
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/v1-orders-20260416-ABC1234567-cancel1320508390'
+            examples:
+              order/cancel-blank-reason:
+                value: "{\"cancelReason\":\"\"}"
+              order/cancel-not-allowed:
+                value: "{\"cancelReason\":\"단순 변심\"}"
+              order/cancel-payment-failed:
+                value: "{\"cancelReason\":\"단순 변심\"}"
+              order/cancel-success:
+                value: "{\"cancelReason\":\"단순 변심\"}"
+      responses:
+        "400":
+          description: "400"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                order/cancel-blank-reason:
+                  value: "{\"success\":false,\"status\":400,\"message\":\"잘못된 입력값입\
+                    니다.\",\"data\":null,\"errors\":[{\"field\":\"cancelReason\",\"\
+                    message\":\"취소 사유를 입력해주세요.\"}]}"
+                order/cancel-not-allowed:
+                  value: "{\"success\":false,\"status\":400,\"message\":\"취소할 수 없는\
+                    \ 주문 상태입니다.\",\"data\":null}"
+        "502":
+          description: "502"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                order/cancel-payment-failed:
+                  value: "{\"success\":false,\"status\":502,\"message\":\"결제 취소에 실\
+                    패했습니다. 관리자에게 문의하세요.\",\"data\":null}"
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+              examples:
+                order/cancel-success:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"주문이 취소되었습\
+                    니다.\",\"data\":null}"
+  /v1/orders/20260416-NOTEXIST00/cancel:
+    post:
+      tags:
+      - Order
+      summary: 주문 전체 취소 - 주문 없음
+      description: 존재하지 않거나 본인 주문이 아닌 경우 404를 반환합니다.
+      operationId: order/cancel-not-found
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/v1-orders-20260416-NOTEXIST00-cancel-1889817476'
+            examples:
+              order/cancel-not-found:
+                value: "{\"cancelReason\":\"단순 변심\"}"
+      responses:
+        "404":
+          description: "404"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                order/cancel-not-found:
+                  value: "{\"success\":false,\"status\":404,\"message\":\"존재하지 않는\
+                    \ 주문입니다.\",\"data\":null}"
   /v1/products/category/{categoryId}:
     get:
       tags:
@@ -1409,6 +1637,50 @@ paths:
                 user-info/find-password-not-found:
                   value: "{\"success\":false,\"status\":404,\"message\":\"존재하지 않는\
                     \ 사용자입니다.\",\"data\":null}"
+  /v1/orders/20260416-ABC1234567/cancel/partial:
+    post:
+      tags:
+      - Order
+      summary: 주문 부분 취소 - 항목 미선택
+      description: orderDetailIds가 비어있으면 400 Bad Request를 반환합니다.
+      operationId: order/cancel-partial-
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/v1-orders-20260416-ABC1234567-cancel-partial-1086755764'
+            examples:
+              order/cancel-partial-empty-ids:
+                value: "{\"orderDetailIds\":[],\"cancelReason\":\"사이즈 오주문\"}"
+              order/cancel-partial-invalid:
+                value: "{\"orderDetailIds\":[10],\"cancelReason\":\"사이즈 오주문\"}"
+              order/cancel-partial-success:
+                value: "{\"orderDetailIds\":[10,11],\"cancelReason\":\"사이즈 오주문\"}"
+      responses:
+        "400":
+          description: "400"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                order/cancel-partial-empty-ids:
+                  value: "{\"success\":false,\"status\":400,\"message\":\"잘못된 입력값입\
+                    니다.\",\"data\":null,\"errors\":[{\"field\":\"orderDetailIds\"\
+                    ,\"message\":\"취소할 주문 항목을 하나 이상 선택해주세요.\"}]}"
+                order/cancel-partial-invalid:
+                  value: "{\"success\":false,\"status\":400,\"message\":\"유효하지 않은\
+                    \ 취소 항목입니다.\",\"data\":null}"
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+              examples:
+                order/cancel-partial-success:
+                  value: "{\"success\":true,\"status\":200,\"message\":\"주문이 취소되었습\
+                    니다.\",\"data\":null}"
   /v1/products/main/category/{categoryId}:
     get:
       tags:
@@ -1700,6 +1972,12 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
+    v1-orders-20260416-ABC1234567-cancel1320508390:
+      type: object
+      properties:
+        cancelReason:
+          type: string
+          description: 취소 사유 (1~200자)
     ProductDetailResponse:
       title: ProductDetailResponse
       type: object
@@ -1779,6 +2057,125 @@ components:
             productName:
               type: string
               description: 상품명
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 응답 메시지
+        status:
+          type: number
+          description: HTTP 상태 코드
+    OrderListResponse:
+      title: OrderListResponse
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            number:
+              type: number
+              description: 현재 페이지 번호
+            numberOfElements:
+              type: number
+              description: 현재 페이지 항목 수
+            size:
+              type: number
+              description: 페이지 크기
+            last:
+              type: boolean
+              description: 마지막 페이지 여부
+            totalPages:
+              type: number
+              description: 전체 페이지 수
+            pageable:
+              type: object
+              properties:
+                paged:
+                  type: boolean
+                  description: 페이징 적용 여부
+                pageNumber:
+                  type: number
+                  description: 현재 페이지 번호
+                offset:
+                  type: number
+                  description: 오프셋
+                pageSize:
+                  type: number
+                  description: 페이지 크기
+                unpaged:
+                  type: boolean
+                  description: 페이징 미적용 여부
+                sort:
+                  type: object
+                  properties:
+                    unsorted:
+                      type: boolean
+                      description: 정렬 미적용 여부
+                    sorted:
+                      type: boolean
+                      description: 정렬 적용 여부
+                    empty:
+                      type: boolean
+                      description: 정렬 조건 없음 여부
+                  description: 정렬 정보
+              description: 페이지 정보
+            sort:
+              type: object
+              properties:
+                unsorted:
+                  type: boolean
+                  description: 정렬 미적용 여부
+                sorted:
+                  type: boolean
+                  description: 정렬 적용 여부
+                empty:
+                  type: boolean
+                  description: 정렬 조건 없음 여부
+              description: 정렬 정보
+            first:
+              type: boolean
+              description: 첫 번째 페이지 여부
+            content:
+              type: array
+              description: 주문 목록 (결과 없음)
+              items:
+                type: object
+                properties:
+                  orderedAt:
+                    type: string
+                    description: 주문 일시
+                  representativeProductName:
+                    type: string
+                    description: 대표 상품명 (첫 번째 상품)
+                  totalQuantity:
+                    type: number
+                    description: 총 상품 수량
+                  orderNumber:
+                    type: string
+                    description: 주문 번호
+                  representativeSize:
+                    type: string
+                    description: 대표 상품 사이즈
+                  orderStatus:
+                    type: string
+                    description: "주문 상태 (PAID, PREPARING_DELIVERY, IN_DELIVERY, DELIVERED,\
+                      \ COMPLETED, CANCELLED 등)"
+                  representativeColor:
+                    type: string
+                    description: 대표 상품 색상
+                  representativeImageUrl:
+                    type: string
+                    description: 대표 상품 이미지 URL
+                  paymentAmount:
+                    type: number
+                    description: 결제 금액
+            empty:
+              type: boolean
+              description: 결과 없음 여부
+            totalElements:
+              type: number
+              description: 전체 주문 수
         success:
           type: boolean
           description: 성공 여부
@@ -1956,6 +2353,34 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
+    OrderStatusCountResponse:
+      title: OrderStatusCountResponse
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            paid:
+              type: number
+              description: 결제완료 건수
+            delivered:
+              type: number
+              description: 배송완료 건수
+            preparingDelivery:
+              type: number
+              description: 배송준비중 건수
+            inDelivery:
+              type: number
+              description: 배송중 건수
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 응답 메시지
+        status:
+          type: number
+          description: HTTP 상태 코드
     WishListSaveRequest:
       title: WishListSaveRequest
       type: object
@@ -2055,6 +2480,12 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
+    v1-orders-20260416-NOTEXIST00-cancel-1889817476:
+      type: object
+      properties:
+        cancelReason:
+          type: string
+          description: 취소 사유
     AddressListResponse:
       title: AddressListResponse
       type: object
@@ -2114,6 +2545,21 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
+    v1-orders-20260416-ABC1234567-cancel-partial-1086755764:
+      type: object
+      properties:
+        orderDetailIds:
+          type: array
+          description: 취소할 주문 항목 ID 목록 (1개 이상)
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        cancelReason:
+          type: string
+          description: 취소 사유 (1~200자)
     CartSaveRequest:
       title: CartSaveRequest
       type: array
@@ -2270,6 +2716,89 @@ components:
               type: string
               description: 발송된 인증번호 (6자리)
           description: 발송 결과
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 응답 메시지
+        status:
+          type: number
+          description: HTTP 상태 코드
+    OrderDetailResponse:
+      title: OrderDetailResponse
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            usedPoint:
+              type: number
+              description: 사용한 포인트
+            orderedAt:
+              type: string
+              description: 주문 일시
+            orderNumber:
+              type: string
+              description: 주문 번호
+            shippingFee:
+              type: number
+              description: 배송비 (5만원 이상 무료)
+            totalOriginalAmount:
+              type: number
+              description: 상품 정가 합계
+            orderStatus:
+              type: string
+              description: 주문 상태
+            details:
+              type: array
+              description: 주문 항목 목록
+              items:
+                type: object
+                properties:
+                  discountRate:
+                    type: number
+                    description: 할인율 (%)
+                  quantity:
+                    type: number
+                    description: 수량
+                  originalPrice:
+                    type: number
+                    description: 정가
+                  size:
+                    type: string
+                    description: 사이즈
+                  color:
+                    type: string
+                    description: 색상명
+                  imageUrl:
+                    type: string
+                    description: 상품 이미지 URL
+                  discountPrice:
+                    type: number
+                    description: 할인 적용가
+                  colorCode:
+                    type: string
+                    description: 색상 코드 (HEX)
+                  productName:
+                    type: string
+                    description: 상품명
+                  productDetailId:
+                    type: number
+                    description: 상품 상세 ID (색상/사이즈 조합)
+                  orderDetailId:
+                    type: number
+                    description: 주문 항목 ID (부분 취소 시 사용)
+                  status:
+                    type: string
+                    description: "항목 상태 (NORMAL, CANCEL_REQUESTED, CANCELLED, REFUND_REQUESTED,\
+                      \ RETURNED)"
+            paymentAmount:
+              type: number
+              description: 최종 결제 금액
+            totalSellingAmount:
+              type: number
+              description: 할인 적용 판매가 합계
         success:
           type: boolean
           description: 성공 여부

--- a/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -416,7 +416,7 @@ paths:
               $ref: '#/components/schemas/v1-users486549215'
             examples:
               user/withdraw-user:
-                value: _csrf=RLB1kcf4plxM95XJG_76cNmEgXTeJLBxVvkyAIpS-cgMJoKwcoZFqPOclmhhk_PwKNPOQL3lrBXoHIhcMMlRZegzmPo0ErWG
+                value: _csrf=z_3LHFv36N9jPq8F8mDkgf8EL9hnm-OTZPgk-DkZiuwzVc---sz7LGLP3-dOWJc3lE3QtcY0AuFfrNq-U8gdnF8uso0LYf-P
       responses:
         "200":
           description: "200"
@@ -783,6 +783,9 @@ paths:
               order/prepare-out-of-stock:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":999}],\"usedPoint\"\
                   :0}"
+              order/prepare-point-exceeds:
+                value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
+                  :99999}"
               order/prepare-success:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
                   :0}"
@@ -812,6 +815,9 @@ paths:
                   value: "{\"success\":false,\"status\":400,\"message\":\"잘못된 입력값입\
                     니다.\",\"data\":null,\"errors\":[{\"field\":\"usedPoint\",\"message\"\
                     :\"포인트는 0 이상이어야 합니다.\"}]}"
+                order/prepare-point-exceeds:
+                  value: "{\"success\":false,\"status\":400,\"message\":\"포인트가 결제\
+                    \ 금액을 초과합니다.\",\"data\":null}"
         "503":
           description: "503"
           content:
@@ -1503,8 +1509,8 @@ paths:
                 user/check-login-id-blank:
                   value: "{\"success\":false,\"status\":400,\"message\":\"잘못된 입력값입\
                     니다.\",\"data\":null,\"errors\":[{\"field\":\"loginId\",\"message\"\
-                    :\"아이디는 4자에서 16자 사이여야 합니다.\"},{\"field\":\"loginId\",\"message\"\
-                    :\"아이디는 비어있어서는 안됩니다.\"}]}"
+                    :\"아이디는 비어있어서는 안됩니다.\"},{\"field\":\"loginId\",\"message\":\"아\
+                    이디는 4자에서 16자 사이여야 합니다.\"}]}"
                 user/check-login-id-invalid:
                   value: "{\"success\":false,\"status\":400,\"message\":\"잘못된 입력값입\
                     니다.\",\"data\":null,\"errors\":[{\"field\":\"loginId\",\"message\"\

--- a/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -416,7 +416,7 @@ paths:
               $ref: '#/components/schemas/v1-users486549215'
             examples:
               user/withdraw-user:
-                value: _csrf=qY3Vpl-8335ER6vf8qD0zyFN-NAetZ4c5XWu6lNKgImJUbWun-_mlW6FuxxpI526xY3ArhV71egqhq4xh02fiWt-5e-xZdbM
+                value: _csrf=F76stX5TRbzUWDHhAoB-1ULcwQKQm3UDD-Oe-Fxm6BIq_df_Lt2egx9lcoj5OlCFY61K4yS47DqiqEwuOtv4yW1SiXMTxbXJ
       responses:
         "200":
           description: "200"

--- a/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/order/controller/OrderControllerTest.java
+++ b/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/order/controller/OrderControllerTest.java
@@ -427,6 +427,47 @@ class OrderControllerTest {
     }
 
     @Test
+    @DisplayName("POST /v1/orders/prepare - 포인트가 결제 금액 초과 시 400 반환")
+    void prepare_pointExceedsPayment() throws Exception {
+        OrderPrepareRequest request = new OrderPrepareRequest(
+            List.of(new OrderItemRequest(1L, 1)),
+            99_999
+        );
+        willThrow(new BusinessException(UserErrorCode.POINT_EXCEEDS_PAYMENT))
+            .given(orderService).prepare(any());
+
+        mockMvc.perform(post("/v1/orders/prepare")
+                .with(authentication(authToken()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.message").value("포인트가 결제 금액을 초과합니다."))
+            .andDo(document("order/prepare-point-exceeds",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 준비 - 포인트 초과")
+                    .description("사용 포인트가 결제 금액(상품금액 + 배송비)보다 크면 400 Bad Request를 반환합니다.")
+                    .responseSchema(Schema.schema("ErrorResponse"))
+                    .requestFields(
+                        fieldWithPath("items").type(JsonFieldType.ARRAY).description("주문 상품 목록"),
+                        fieldWithPath("items[].productDetailId").type(JsonFieldType.NUMBER).description("상품 상세 ID"),
+                        fieldWithPath("items[].quantity").type(JsonFieldType.NUMBER).description("수량"),
+                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트 (결제 금액 초과)")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.VARIES).optional().description("응답 데이터 (없음)")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
     @DisplayName("POST /v1/orders/prepare - 인증 없이 접근 시 401 반환")
     void prepare_unauthorized() throws Exception {
         OrderPrepareRequest request = new OrderPrepareRequest(

--- a/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/order/controller/OrderControllerTest.java
+++ b/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/order/controller/OrderControllerTest.java
@@ -7,7 +7,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -16,17 +18,25 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.daebbang.daebbangapi.config.PasswordConfig;
 import com.daebbang.daebbangapi.config.TestSecurityConfig;
 import com.daebbang.daebbangapi.domain.oauth.service.oauth2.Oauth2UserDetailsService;
+import com.daebbang.daebbangapi.domain.order.dto.request.OrderCancelRequest;
 import com.daebbang.daebbangapi.domain.order.dto.request.OrderConfirmRequest;
 import com.daebbang.daebbangapi.domain.order.dto.request.OrderItemRequest;
+import com.daebbang.daebbangapi.domain.order.dto.request.OrderPartialCancelRequest;
 import com.daebbang.daebbangapi.domain.order.dto.request.OrderPrepareRequest;
 import com.daebbang.daebbangapi.domain.users.service.CustomUserDetailsService;
 import com.daebbang.daebbangcommon.error.BusinessException;
 import com.daebbang.daebbangcommon.error.UserErrorCode;
+import com.daebbang.daebbangcore.domain.order.dto.OrderFullDetailResult;
 import com.daebbang.daebbangcore.domain.order.dto.OrderPrepareResponse;
+import com.daebbang.daebbangcore.domain.order.dto.OrderStatusCountResult;
+import com.daebbang.daebbangcore.domain.order.dto.OrderSummaryResult;
+import com.daebbang.daebbangcore.domain.order.entity.OrderDetailStatus;
+import com.daebbang.daebbangcore.domain.order.entity.OrderStatus;
 import com.daebbang.daebbangcore.domain.order.service.OrderService;
 import com.daebbang.daebbangcore.infra.util.JwtUtils;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,6 +44,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -791,6 +804,653 @@ class OrderControllerTest {
         mockMvc.perform(post("/v1/orders/confirm")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isUnauthorized());
+    }
+
+    // ======================== POST /v1/orders/{orderNumber}/cancel ========================
+
+    @Test
+    @DisplayName("POST /v1/orders/{orderNumber}/cancel - 전체 취소 성공")
+    void cancel_success() throws Exception {
+        OrderCancelRequest request = new OrderCancelRequest("단순 변심");
+        willDoNothing().given(orderService).cancel(any());
+
+        mockMvc.perform(post("/v1/orders/20260416-ABC1234567/cancel")
+                .with(authentication(authToken()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.message").value("주문이 취소되었습니다."))
+            .andDo(document("order/cancel-success",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 전체 취소")
+                    .description("""
+                        결제완료(PAID), 배송준비중(PREPARING_DELIVERY) 상태의 주문을 전체 취소합니다.
+                        가상계좌 입금 대기(WAITING_DEPOSIT) 상태도 취소 가능합니다.
+                        배송중(IN_DELIVERY) 이후에는 취소가 불가능합니다.
+                        취소 성공 시 결제 취소(토스 API 호출), 재고 복원이 자동으로 처리됩니다.
+                        """)
+                    .requestSchema(Schema.schema("OrderCancelRequest"))
+                    .responseSchema(Schema.schema("SuccessResponse"))
+                    .requestFields(
+                        fieldWithPath("cancelReason").type(JsonFieldType.STRING).description("취소 사유 (1~200자)")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.VARIES).optional().description("응답 데이터 (없음)")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("POST /v1/orders/{orderNumber}/cancel - cancelReason 빈 문자열이면 400 반환")
+    void cancel_blankReason() throws Exception {
+        OrderCancelRequest request = new OrderCancelRequest("");
+
+        mockMvc.perform(post("/v1/orders/20260416-ABC1234567/cancel")
+                .with(authentication(authToken()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.status").value(400))
+            .andDo(document("order/cancel-blank-reason",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 전체 취소 - 취소 사유 누락")
+                    .description("취소 사유가 빈 문자열이면 400 Bad Request를 반환합니다.")
+                    .responseSchema(Schema.schema("ErrorResponse"))
+                    .requestFields(
+                        fieldWithPath("cancelReason").type(JsonFieldType.STRING).description("취소 사유 (빈 문자열 - 오류)")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.VARIES).optional().description("응답 데이터 (없음)"),
+                        fieldWithPath("errors").type(JsonFieldType.ARRAY).optional().description("유효성 검증 오류 목록"),
+                        fieldWithPath("errors[].field").type(JsonFieldType.STRING).optional().description("오류 필드명"),
+                        fieldWithPath("errors[].message").type(JsonFieldType.STRING).optional().description("오류 메시지")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("POST /v1/orders/{orderNumber}/cancel - 존재하지 않는 주문이면 404 반환")
+    void cancel_orderNotFound() throws Exception {
+        OrderCancelRequest request = new OrderCancelRequest("단순 변심");
+        willThrow(new BusinessException(UserErrorCode.ORDER_NOT_FOUND))
+            .given(orderService).cancel(any());
+
+        mockMvc.perform(post("/v1/orders/20260416-NOTEXIST00/cancel")
+                .with(authentication(authToken()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.message").value("존재하지 않는 주문입니다."))
+            .andDo(document("order/cancel-not-found",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 전체 취소 - 주문 없음")
+                    .description("존재하지 않거나 본인 주문이 아닌 경우 404를 반환합니다.")
+                    .responseSchema(Schema.schema("ErrorResponse"))
+                    .requestFields(
+                        fieldWithPath("cancelReason").type(JsonFieldType.STRING).description("취소 사유")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.VARIES).optional().description("응답 데이터 (없음)")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("POST /v1/orders/{orderNumber}/cancel - 취소 불가 상태(배송중)이면 400 반환")
+    void cancel_notAllowed() throws Exception {
+        OrderCancelRequest request = new OrderCancelRequest("단순 변심");
+        willThrow(new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED))
+            .given(orderService).cancel(any());
+
+        mockMvc.perform(post("/v1/orders/20260416-ABC1234567/cancel")
+                .with(authentication(authToken()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.message").value("취소할 수 없는 주문 상태입니다."))
+            .andDo(document("order/cancel-not-allowed",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 전체 취소 - 취소 불가 상태")
+                    .description("배송중(IN_DELIVERY), 배송완료(DELIVERED) 등 취소 불가 상태의 주문은 400을 반환합니다.")
+                    .responseSchema(Schema.schema("ErrorResponse"))
+                    .requestFields(
+                        fieldWithPath("cancelReason").type(JsonFieldType.STRING).description("취소 사유")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.VARIES).optional().description("응답 데이터 (없음)")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("POST /v1/orders/{orderNumber}/cancel - 토스 결제 취소 실패 시 502 반환")
+    void cancel_paymentCancelFailed() throws Exception {
+        OrderCancelRequest request = new OrderCancelRequest("단순 변심");
+        willThrow(new BusinessException(UserErrorCode.PAYMENT_CANCEL_FAILED))
+            .given(orderService).cancel(any());
+
+        mockMvc.perform(post("/v1/orders/20260416-ABC1234567/cancel")
+                .with(authentication(authToken()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isBadGateway())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.message").value("결제 취소에 실패했습니다. 관리자에게 문의하세요."))
+            .andDo(document("order/cancel-payment-failed",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 전체 취소 - 결제 취소 실패")
+                    .description("토스 결제 취소 API 호출에 실패한 경우 502를 반환합니다. DB는 롤백되며 주문 상태는 변경되지 않습니다.")
+                    .responseSchema(Schema.schema("ErrorResponse"))
+                    .requestFields(
+                        fieldWithPath("cancelReason").type(JsonFieldType.STRING).description("취소 사유")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.VARIES).optional().description("응답 데이터 (없음)")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("POST /v1/orders/{orderNumber}/cancel - 인증 없이 접근 시 401 반환")
+    void cancel_unauthorized() throws Exception {
+        OrderCancelRequest request = new OrderCancelRequest("단순 변심");
+
+        mockMvc.perform(post("/v1/orders/20260416-ABC1234567/cancel")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isUnauthorized());
+    }
+
+    // ======================== POST /v1/orders/{orderNumber}/cancel/partial ========================
+
+    @Test
+    @DisplayName("POST /v1/orders/{orderNumber}/cancel/partial - 부분 취소 성공")
+    void cancelPartial_success() throws Exception {
+        OrderPartialCancelRequest request = new OrderPartialCancelRequest(List.of(10L, 11L), "사이즈 오주문");
+        willDoNothing().given(orderService).cancelPartial(any());
+
+        mockMvc.perform(post("/v1/orders/20260416-ABC1234567/cancel/partial")
+                .with(authentication(authToken()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.message").value("주문이 취소되었습니다."))
+            .andDo(document("order/cancel-partial-success",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 부분 취소")
+                    .description("""
+                        주문 내 특정 상품(orderDetailId)만 선택적으로 취소합니다.
+                        선택한 항목의 금액만큼 부분 환불이 진행됩니다.
+                        모든 항목이 취소되면 주문 전체가 CANCELLED 상태로 변경됩니다.
+                        이미 취소된 항목을 포함하거나, 다른 주문의 항목 ID를 전달하면 400을 반환합니다.
+                        """)
+                    .requestSchema(Schema.schema("OrderPartialCancelRequest"))
+                    .responseSchema(Schema.schema("SuccessResponse"))
+                    .requestFields(
+                        fieldWithPath("orderDetailIds").type(JsonFieldType.ARRAY).description("취소할 주문 항목 ID 목록 (1개 이상)"),
+                        fieldWithPath("cancelReason").type(JsonFieldType.STRING).description("취소 사유 (1~200자)")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.VARIES).optional().description("응답 데이터 (없음)")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("POST /v1/orders/{orderNumber}/cancel/partial - orderDetailIds 빈 배열이면 400 반환")
+    void cancelPartial_emptyDetailIds() throws Exception {
+        OrderPartialCancelRequest request = new OrderPartialCancelRequest(List.of(), "사이즈 오주문");
+
+        mockMvc.perform(post("/v1/orders/20260416-ABC1234567/cancel/partial")
+                .with(authentication(authToken()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.status").value(400))
+            .andDo(document("order/cancel-partial-empty-ids",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 부분 취소 - 항목 미선택")
+                    .description("orderDetailIds가 비어있으면 400 Bad Request를 반환합니다.")
+                    .responseSchema(Schema.schema("ErrorResponse"))
+                    .requestFields(
+                        fieldWithPath("orderDetailIds").type(JsonFieldType.ARRAY).description("취소할 항목 ID 목록 (비어있음 - 오류)"),
+                        fieldWithPath("cancelReason").type(JsonFieldType.STRING).description("취소 사유")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.VARIES).optional().description("응답 데이터 (없음)"),
+                        fieldWithPath("errors").type(JsonFieldType.ARRAY).optional().description("유효성 검증 오류 목록"),
+                        fieldWithPath("errors[].field").type(JsonFieldType.STRING).optional().description("오류 필드명"),
+                        fieldWithPath("errors[].message").type(JsonFieldType.STRING).optional().description("오류 메시지")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("POST /v1/orders/{orderNumber}/cancel/partial - 유효하지 않은 항목(이미 취소됨)이면 400 반환")
+    void cancelPartial_invalidItem() throws Exception {
+        OrderPartialCancelRequest request = new OrderPartialCancelRequest(List.of(10L), "사이즈 오주문");
+        willThrow(new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID))
+            .given(orderService).cancelPartial(any());
+
+        mockMvc.perform(post("/v1/orders/20260416-ABC1234567/cancel/partial")
+                .with(authentication(authToken()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.message").value("유효하지 않은 취소 항목입니다."))
+            .andDo(document("order/cancel-partial-invalid",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 부분 취소 - 유효하지 않은 항목")
+                    .description("이미 취소된 항목이거나 해당 주문에 속하지 않는 항목 ID가 포함된 경우 400을 반환합니다.")
+                    .responseSchema(Schema.schema("ErrorResponse"))
+                    .requestFields(
+                        fieldWithPath("orderDetailIds").type(JsonFieldType.ARRAY).description("취소할 항목 ID 목록 (이미 취소된 항목 포함)"),
+                        fieldWithPath("cancelReason").type(JsonFieldType.STRING).description("취소 사유")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.VARIES).optional().description("응답 데이터 (없음)")
+                    )
+                    .build()
+                )));
+    }
+
+    // ======================== GET /v1/orders ========================
+
+    @Test
+    @DisplayName("GET /v1/orders - 주문 목록 조회 성공 (기본 3개월)")
+    void getOrderList_success() throws Exception {
+        OrderSummaryResult summary = new OrderSummaryResult(
+            1L, "20260416-ABC1234567", OrderStatus.PAID,
+            LocalDateTime.of(2026, 4, 16, 10, 0, 0),
+            33_000, 2, "빵집 크루아상", "https://cdn.daebbang.com/img/croissant.jpg",
+            "골드", "M"
+        );
+        Page<OrderSummaryResult> page = new PageImpl<>(List.of(summary), PageRequest.of(0, 10), 1);
+        given(orderService.getOrderList(any(), any(), any(), any())).willReturn(page);
+
+        mockMvc.perform(get("/v1/orders")
+                .with(authentication(authToken()))
+                .param("page", "0")
+                .param("size", "10"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.message").value("주문 목록 조회에 성공하였습니다."))
+            .andExpect(jsonPath("$.data.content[0].orderNumber").value("20260416-ABC1234567"))
+            .andExpect(jsonPath("$.data.content[0].orderStatus").value("PAID"))
+            .andExpect(jsonPath("$.data.content[0].paymentAmount").value(33_000))
+            .andExpect(jsonPath("$.data.content[0].totalQuantity").value(2))
+            .andExpect(jsonPath("$.data.content[0].representativeProductName").value("빵집 크루아상"))
+            .andDo(document("order/list-success",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 목록 조회")
+                    .description("""
+                        로그인한 사용자의 주문 목록을 페이징하여 반환합니다.
+                        기본 조회 범위는 최근 3개월이며 최대 1년까지 조회 가능합니다.
+                        startDate를 1년 이전으로 지정하면 자동으로 1년 전으로 보정됩니다.
+                        날짜 형식: yyyy-MM-dd
+                        """)
+                    .responseSchema(Schema.schema("OrderListResponse"))
+                    .queryParameters(
+                        parameterWithName("startDate").optional().description("조회 시작일 (yyyy-MM-dd, 기본값: 오늘 - 3개월, 최대 1년 전)"),
+                        parameterWithName("endDate").optional().description("조회 종료일 (yyyy-MM-dd, 기본값: 오늘)"),
+                        parameterWithName("page").optional().description("페이지 번호 (0부터 시작, 기본값: 0)"),
+                        parameterWithName("size").optional().description("페이지 크기 (기본값: 10)")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.content[]").type(JsonFieldType.ARRAY).description("주문 목록"),
+                        fieldWithPath("data.content[].orderNumber").type(JsonFieldType.STRING).description("주문 번호"),
+                        fieldWithPath("data.content[].orderStatus").type(JsonFieldType.STRING).description("주문 상태 (PAID, PREPARING_DELIVERY, IN_DELIVERY, DELIVERED, COMPLETED, CANCELLED 등)"),
+                        fieldWithPath("data.content[].orderedAt").type(JsonFieldType.STRING).description("주문 일시"),
+                        fieldWithPath("data.content[].paymentAmount").type(JsonFieldType.NUMBER).description("결제 금액"),
+                        fieldWithPath("data.content[].totalQuantity").type(JsonFieldType.NUMBER).description("총 상품 수량"),
+                        fieldWithPath("data.content[].representativeProductName").type(JsonFieldType.STRING).description("대표 상품명 (첫 번째 상품)"),
+                        fieldWithPath("data.content[].representativeImageUrl").type(JsonFieldType.STRING).description("대표 상품 이미지 URL"),
+                        fieldWithPath("data.content[].representativeColor").type(JsonFieldType.STRING).description("대표 상품 색상"),
+                        fieldWithPath("data.content[].representativeSize").type(JsonFieldType.STRING).description("대표 상품 사이즈"),
+                        fieldWithPath("data.pageable").type(JsonFieldType.OBJECT).description("페이지 정보"),
+                        fieldWithPath("data.pageable.pageNumber").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                        fieldWithPath("data.pageable.pageSize").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                        fieldWithPath("data.pageable.sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                        fieldWithPath("data.pageable.sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬 적용 여부"),
+                        fieldWithPath("data.pageable.sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬 미적용 여부"),
+                        fieldWithPath("data.pageable.sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 조건 없음 여부"),
+                        fieldWithPath("data.pageable.offset").type(JsonFieldType.NUMBER).description("오프셋"),
+                        fieldWithPath("data.pageable.paged").type(JsonFieldType.BOOLEAN).description("페이징 적용 여부"),
+                        fieldWithPath("data.pageable.unpaged").type(JsonFieldType.BOOLEAN).description("페이징 미적용 여부"),
+                        fieldWithPath("data.totalElements").type(JsonFieldType.NUMBER).description("전체 주문 수"),
+                        fieldWithPath("data.totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 수"),
+                        fieldWithPath("data.last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                        fieldWithPath("data.first").type(JsonFieldType.BOOLEAN).description("첫 번째 페이지 여부"),
+                        fieldWithPath("data.size").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                        fieldWithPath("data.number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                        fieldWithPath("data.sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                        fieldWithPath("data.sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬 적용 여부"),
+                        fieldWithPath("data.sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬 미적용 여부"),
+                        fieldWithPath("data.sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 조건 없음 여부"),
+                        fieldWithPath("data.numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지 항목 수"),
+                        fieldWithPath("data.empty").type(JsonFieldType.BOOLEAN).description("결과 없음 여부")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("GET /v1/orders - 날짜 범위 지정 조회 성공")
+    void getOrderList_withDateRange() throws Exception {
+        given(orderService.getOrderList(any(), any(), any(), any()))
+            .willReturn(Page.empty());
+
+        mockMvc.perform(get("/v1/orders")
+                .with(authentication(authToken()))
+                .param("startDate", "2026-01-01")
+                .param("endDate", "2026-03-31"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.content").isEmpty())
+            .andDo(document("order/list-with-date-range",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 목록 조회 - 날짜 범위 지정")
+                    .description("startDate와 endDate를 지정하여 특정 기간의 주문을 조회합니다.")
+                    .responseSchema(Schema.schema("OrderListResponse"))
+                    .queryParameters(
+                        parameterWithName("startDate").optional().description("조회 시작일 (2026-01-01)"),
+                        parameterWithName("endDate").optional().description("조회 종료일 (2026-03-31)")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.content[]").type(JsonFieldType.ARRAY).description("주문 목록 (결과 없음)"),
+                        fieldWithPath("data.pageable").type(JsonFieldType.STRING).description("페이지 정보"),
+                        fieldWithPath("data.totalElements").type(JsonFieldType.NUMBER).description("전체 주문 수"),
+                        fieldWithPath("data.totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 수"),
+                        fieldWithPath("data.last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                        fieldWithPath("data.first").type(JsonFieldType.BOOLEAN).description("첫 번째 페이지 여부"),
+                        fieldWithPath("data.size").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                        fieldWithPath("data.number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                        fieldWithPath("data.sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                        fieldWithPath("data.sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬 적용 여부"),
+                        fieldWithPath("data.sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬 미적용 여부"),
+                        fieldWithPath("data.sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 조건 없음 여부"),
+                        fieldWithPath("data.numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지 항목 수"),
+                        fieldWithPath("data.empty").type(JsonFieldType.BOOLEAN).description("결과 없음 여부")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("GET /v1/orders - 인증 없이 접근 시 401 반환")
+    void getOrderList_unauthorized() throws Exception {
+        mockMvc.perform(get("/v1/orders"))
+            .andDo(print())
+            .andExpect(status().isUnauthorized());
+    }
+
+    // ======================== GET /v1/orders/{orderNumber} ========================
+
+    @Test
+    @DisplayName("GET /v1/orders/{orderNumber} - 주문 상세 조회 성공")
+    void getOrderDetail_success() throws Exception {
+        OrderFullDetailResult.OrderDetailItem item = new OrderFullDetailResult.OrderDetailItem(
+            10L, 101L, "빵집 크루아상",
+            "https://cdn.daebbang.com/img/croissant.jpg",
+            "골드", "#FFD700", "M",
+            2, 15_000, 10, 13_500, OrderDetailStatus.NORMAL
+        );
+        OrderFullDetailResult result = new OrderFullDetailResult(
+            "20260416-ABC1234567", OrderStatus.PAID,
+            LocalDateTime.of(2026, 4, 16, 10, 0, 0),
+            30_000, 27_000, 3_000, 0, 30_000,
+            List.of(item)
+        );
+        given(orderService.getOrderDetail(any(), any())).willReturn(result);
+
+        mockMvc.perform(get("/v1/orders/20260416-ABC1234567")
+                .with(authentication(authToken())))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.message").value("주문 상세 조회에 성공하였습니다."))
+            .andExpect(jsonPath("$.data.orderNumber").value("20260416-ABC1234567"))
+            .andExpect(jsonPath("$.data.orderStatus").value("PAID"))
+            .andExpect(jsonPath("$.data.totalOriginalAmount").value(30_000))
+            .andExpect(jsonPath("$.data.totalSellingAmount").value(27_000))
+            .andExpect(jsonPath("$.data.shippingFee").value(3_000))
+            .andExpect(jsonPath("$.data.usedPoint").value(0))
+            .andExpect(jsonPath("$.data.paymentAmount").value(30_000))
+            .andExpect(jsonPath("$.data.details[0].orderDetailId").value(10))
+            .andExpect(jsonPath("$.data.details[0].productDetailId").value(101))
+            .andExpect(jsonPath("$.data.details[0].productName").value("빵집 크루아상"))
+            .andExpect(jsonPath("$.data.details[0].status").value("NORMAL"))
+            .andDo(document("order/detail-success",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 상세 조회")
+                    .description("""
+                        주문 번호로 해당 주문의 상세 정보를 조회합니다.
+                        본인 주문만 조회 가능하며 타인의 주문 번호를 전달하면 404를 반환합니다.
+                        orderDetailId를 통해 부분 취소 API에서 항목을 지정할 수 있습니다.
+                        """)
+                    .responseSchema(Schema.schema("OrderDetailResponse"))
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.orderNumber").type(JsonFieldType.STRING).description("주문 번호"),
+                        fieldWithPath("data.orderStatus").type(JsonFieldType.STRING).description("주문 상태"),
+                        fieldWithPath("data.orderedAt").type(JsonFieldType.STRING).description("주문 일시"),
+                        fieldWithPath("data.totalOriginalAmount").type(JsonFieldType.NUMBER).description("상품 정가 합계"),
+                        fieldWithPath("data.totalSellingAmount").type(JsonFieldType.NUMBER).description("할인 적용 판매가 합계"),
+                        fieldWithPath("data.shippingFee").type(JsonFieldType.NUMBER).description("배송비 (5만원 이상 무료)"),
+                        fieldWithPath("data.usedPoint").type(JsonFieldType.NUMBER).description("사용한 포인트"),
+                        fieldWithPath("data.paymentAmount").type(JsonFieldType.NUMBER).description("최종 결제 금액"),
+                        fieldWithPath("data.details[]").type(JsonFieldType.ARRAY).description("주문 항목 목록"),
+                        fieldWithPath("data.details[].orderDetailId").type(JsonFieldType.NUMBER).description("주문 항목 ID (부분 취소 시 사용)"),
+                        fieldWithPath("data.details[].productDetailId").type(JsonFieldType.NUMBER).description("상품 상세 ID (색상/사이즈 조합)"),
+                        fieldWithPath("data.details[].productName").type(JsonFieldType.STRING).description("상품명"),
+                        fieldWithPath("data.details[].imageUrl").type(JsonFieldType.STRING).description("상품 이미지 URL"),
+                        fieldWithPath("data.details[].color").type(JsonFieldType.STRING).description("색상명"),
+                        fieldWithPath("data.details[].colorCode").type(JsonFieldType.STRING).description("색상 코드 (HEX)"),
+                        fieldWithPath("data.details[].size").type(JsonFieldType.STRING).description("사이즈"),
+                        fieldWithPath("data.details[].quantity").type(JsonFieldType.NUMBER).description("수량"),
+                        fieldWithPath("data.details[].originalPrice").type(JsonFieldType.NUMBER).description("정가"),
+                        fieldWithPath("data.details[].discountRate").type(JsonFieldType.NUMBER).description("할인율 (%)"),
+                        fieldWithPath("data.details[].discountPrice").type(JsonFieldType.NUMBER).description("할인 적용가"),
+                        fieldWithPath("data.details[].status").type(JsonFieldType.STRING).description("항목 상태 (NORMAL, CANCEL_REQUESTED, CANCELLED, REFUND_REQUESTED, RETURNED)")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("GET /v1/orders/{orderNumber} - 존재하지 않는 주문이면 404 반환")
+    void getOrderDetail_notFound() throws Exception {
+        willThrow(new BusinessException(UserErrorCode.ORDER_NOT_FOUND))
+            .given(orderService).getOrderDetail(any(), any());
+
+        mockMvc.perform(get("/v1/orders/20260416-NOTEXIST00")
+                .with(authentication(authToken())))
+            .andDo(print())
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.message").value("존재하지 않는 주문입니다."))
+            .andDo(document("order/detail-not-found",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("주문 상세 조회 - 주문 없음")
+                    .description("존재하지 않거나 본인 주문이 아닌 경우 404를 반환합니다.")
+                    .responseSchema(Schema.schema("ErrorResponse"))
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("오류 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.VARIES).optional().description("응답 데이터 (없음)")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("GET /v1/orders/{orderNumber} - 인증 없이 접근 시 401 반환")
+    void getOrderDetail_unauthorized() throws Exception {
+        mockMvc.perform(get("/v1/orders/20260416-ABC1234567"))
+            .andDo(print())
+            .andExpect(status().isUnauthorized());
+    }
+
+    // ======================== GET /v1/orders/status-count ========================
+
+    @Test
+    @DisplayName("GET /v1/orders/status-count - 배송 현황 건수 조회 성공")
+    void getOrderStatusCount_success() throws Exception {
+        OrderStatusCountResult result = new OrderStatusCountResult(2L, 1L, 3L, 1L);
+        given(orderService.getOrderStatusCount(any(), any(), any())).willReturn(result);
+
+        mockMvc.perform(get("/v1/orders/status-count")
+                .with(authentication(authToken())))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.message").value("배송 현황 건수 조회에 성공하였습니다."))
+            .andExpect(jsonPath("$.data.paid").value(2))
+            .andExpect(jsonPath("$.data.preparingDelivery").value(1))
+            .andExpect(jsonPath("$.data.inDelivery").value(3))
+            .andExpect(jsonPath("$.data.delivered").value(1))
+            .andDo(document("order/status-count-success",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("배송 현황 건수 조회")
+                    .description("""
+                        마이페이지 상단에 표시할 배송 현황 건수를 반환합니다.
+                        결제완료 / 배송준비중 / 배송중 / 배송완료 4가지 상태별 건수를 제공합니다.
+                        날짜 범위를 지정하지 않으면 기본 3개월 기준으로 집계하며 최대 1년까지 조회 가능합니다.
+                        """)
+                    .responseSchema(Schema.schema("OrderStatusCountResponse"))
+                    .queryParameters(
+                        parameterWithName("startDate").optional().description("조회 시작일 (yyyy-MM-dd, 기본값: 오늘 - 3개월)"),
+                        parameterWithName("endDate").optional().description("조회 종료일 (yyyy-MM-dd, 기본값: 오늘)")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.paid").type(JsonFieldType.NUMBER).description("결제완료(PAID) 건수"),
+                        fieldWithPath("data.preparingDelivery").type(JsonFieldType.NUMBER).description("배송준비중(PREPARING_DELIVERY) 건수"),
+                        fieldWithPath("data.inDelivery").type(JsonFieldType.NUMBER).description("배송중(IN_DELIVERY) 건수"),
+                        fieldWithPath("data.delivered").type(JsonFieldType.NUMBER).description("배송완료(DELIVERED) 건수")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("GET /v1/orders/status-count - 날짜 범위 지정 조회 성공")
+    void getOrderStatusCount_withDateRange() throws Exception {
+        OrderStatusCountResult result = new OrderStatusCountResult(0L, 0L, 0L, 0L);
+        given(orderService.getOrderStatusCount(any(), any(), any())).willReturn(result);
+
+        mockMvc.perform(get("/v1/orders/status-count")
+                .with(authentication(authToken()))
+                .param("startDate", "2026-01-01")
+                .param("endDate", "2026-01-31"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.paid").value(0))
+            .andExpect(jsonPath("$.data.preparingDelivery").value(0))
+            .andExpect(jsonPath("$.data.inDelivery").value(0))
+            .andExpect(jsonPath("$.data.delivered").value(0))
+            .andDo(document("order/status-count-with-date-range",
+                resource(ResourceSnippetParameters.builder()
+                    .tag("Order")
+                    .summary("배송 현황 건수 조회 - 날짜 범위 지정")
+                    .description("특정 기간의 배송 현황 건수를 조회합니다. 해당 기간에 주문이 없으면 모두 0으로 반환합니다.")
+                    .responseSchema(Schema.schema("OrderStatusCountResponse"))
+                    .queryParameters(
+                        parameterWithName("startDate").optional().description("조회 시작일 (2026-01-01)"),
+                        parameterWithName("endDate").optional().description("조회 종료일 (2026-01-31)")
+                    )
+                    .responseFields(
+                        fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.paid").type(JsonFieldType.NUMBER).description("결제완료 건수"),
+                        fieldWithPath("data.preparingDelivery").type(JsonFieldType.NUMBER).description("배송준비중 건수"),
+                        fieldWithPath("data.inDelivery").type(JsonFieldType.NUMBER).description("배송중 건수"),
+                        fieldWithPath("data.delivered").type(JsonFieldType.NUMBER).description("배송완료 건수")
+                    )
+                    .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("GET /v1/orders/status-count - 인증 없이 접근 시 401 반환")
+    void getOrderStatusCount_unauthorized() throws Exception {
+        mockMvc.perform(get("/v1/orders/status-count"))
             .andDo(print())
             .andExpect(status().isUnauthorized());
     }

--- a/daebbang-common/src/main/java/com/daebbang/daebbangcommon/error/UserErrorCode.java
+++ b/daebbang-common/src/main/java/com/daebbang/daebbangcommon/error/UserErrorCode.java
@@ -59,7 +59,9 @@ public enum UserErrorCode implements ErrorCode {
     PAYMENT_CANCEL_FAILED(502, "결제 취소에 실패했습니다. 관리자에게 문의하세요."),
 
     ORDER_CANCEL_NOT_ALLOWED(400, "취소할 수 없는 주문 상태입니다."),
-    ORDER_PARTIAL_CANCEL_INVALID(400, "유효하지 않은 취소 항목입니다.");
+    ORDER_PARTIAL_CANCEL_INVALID(400, "유효하지 않은 취소 항목입니다."),
+    ORDER_DATE_RANGE_INVALID(400, "조회 시작일이 종료일보다 늦을 수 없습니다."),
+    STOCK_RESTORE_FAILED(500, "재고 복원에 실패했습니다. 관리자에게 문의하세요.");
 
     private final int status;
     private final String message;

--- a/daebbang-common/src/main/java/com/daebbang/daebbangcommon/error/UserErrorCode.java
+++ b/daebbang-common/src/main/java/com/daebbang/daebbangcommon/error/UserErrorCode.java
@@ -61,6 +61,7 @@ public enum UserErrorCode implements ErrorCode {
     ORDER_CANCEL_NOT_ALLOWED(400, "취소할 수 없는 주문 상태입니다."),
     ORDER_PARTIAL_CANCEL_INVALID(400, "유효하지 않은 취소 항목입니다."),
     ORDER_DATE_RANGE_INVALID(400, "조회 시작일이 종료일보다 늦을 수 없습니다."),
+    POINT_EXCEEDS_PAYMENT(400, "포인트가 결제 금액을 초과합니다."),
     STOCK_RESTORE_FAILED(500, "재고 복원에 실패했습니다. 관리자에게 문의하세요.");
 
     private final int status;

--- a/daebbang-common/src/main/java/com/daebbang/daebbangcommon/error/UserErrorCode.java
+++ b/daebbang-common/src/main/java/com/daebbang/daebbangcommon/error/UserErrorCode.java
@@ -54,7 +54,12 @@ public enum UserErrorCode implements ErrorCode {
     ORDER_ALREADY_PROCESSED(409, "이미 처리된 주문입니다."),
     OUT_OF_STOCK(409, "재고가 부족합니다."),
     STOCK_LOCK_FAILED(503, "재고 처리 중입니다. 잠시 후 다시 시도해주세요."),
-    PAYMENT_CONFIRMATION_FAILED(502, "결제 승인에 실패했습니다. 관리자에게 문의하세요.");
+    PAYMENT_CONFIRMATION_FAILED(502, "결제 승인에 실패했습니다. 관리자에게 문의하세요."),
+    PAYMENT_NOT_FOUND(404, "결제 정보를 찾을 수 없습니다."),
+    PAYMENT_CANCEL_FAILED(502, "결제 취소에 실패했습니다. 관리자에게 문의하세요."),
+
+    ORDER_CANCEL_NOT_ALLOWED(400, "취소할 수 없는 주문 상태입니다."),
+    ORDER_PARTIAL_CANCEL_INVALID(400, "유효하지 않은 취소 항목입니다.");
 
     private final int status;
     private final String message;

--- a/daebbang-common/src/main/java/com/daebbang/daebbangcommon/success/UserSuccessCode.java
+++ b/daebbang-common/src/main/java/com/daebbang/daebbangcommon/success/UserSuccessCode.java
@@ -30,7 +30,10 @@ public enum UserSuccessCode implements SuccessCode {
 
     ORDER_PREPARED(200, "주문이 생성되었습니다."),
     ORDER_CONFIRMED(200, "결제가 완료되었습니다."),
-    ORDER_CANCELLED(200, "주문이 취소되었습니다.");
+    ORDER_CANCELLED(200, "주문이 취소되었습니다."),
+    ORDER_LIST_RETRIEVED(200, "주문 목록 조회에 성공하였습니다."),
+    ORDER_DETAIL_RETRIEVED(200, "주문 상세 조회에 성공하였습니다."),
+    ORDER_STATUS_COUNT_RETRIEVED(200, "배송 현황 건수 조회에 성공하였습니다.");
 
     private final int status;
     private final String message;

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/command/OrderCancelCommand.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/command/OrderCancelCommand.java
@@ -1,0 +1,7 @@
+package com.daebbang.daebbangcore.domain.order.command;
+
+public record OrderCancelCommand(
+    Long userId,
+    String orderNumber,
+    String cancelReason
+) {}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/command/OrderPartialCancelCommand.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/command/OrderPartialCancelCommand.java
@@ -1,0 +1,10 @@
+package com.daebbang.daebbangcore.domain.order.command;
+
+import java.util.List;
+
+public record OrderPartialCancelCommand(
+    Long userId,
+    String orderNumber,
+    List<Long> orderDetailIds,
+    String cancelReason
+) {}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/dto/OrderFullDetailResult.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/dto/OrderFullDetailResult.java
@@ -1,0 +1,33 @@
+package com.daebbang.daebbangcore.domain.order.dto;
+
+import com.daebbang.daebbangcore.domain.order.entity.OrderDetailStatus;
+import com.daebbang.daebbangcore.domain.order.entity.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderFullDetailResult(
+    String orderNumber,
+    OrderStatus orderStatus,
+    LocalDateTime orderedAt,
+    int totalOriginalAmount,
+    int totalSellingAmount,
+    int shippingFee,
+    int usedPoint,
+    int paymentAmount,
+    List<OrderDetailItem> details
+) {
+    public record OrderDetailItem(
+        Long orderDetailId,
+        Long productDetailId,
+        String productName,
+        String imageUrl,
+        String color,
+        String colorCode,
+        String size,
+        int quantity,
+        int originalPrice,
+        int discountRate,
+        int discountPrice,
+        OrderDetailStatus status
+    ) {}
+}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/dto/OrderStatusCountResult.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/dto/OrderStatusCountResult.java
@@ -1,0 +1,8 @@
+package com.daebbang.daebbangcore.domain.order.dto;
+
+public record OrderStatusCountResult(
+    long paid,               // 결제완료 (PAID)
+    long preparingDelivery,  // 배송준비중 (PREPARING_DELIVERY)
+    long inDelivery,         // 배송중 (IN_DELIVERY)
+    long delivered           // 배송완료 (DELIVERED)
+) {}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/dto/OrderSummaryResult.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/dto/OrderSummaryResult.java
@@ -1,0 +1,17 @@
+package com.daebbang.daebbangcore.domain.order.dto;
+
+import com.daebbang.daebbangcore.domain.order.entity.OrderStatus;
+import java.time.LocalDateTime;
+
+public record OrderSummaryResult(
+    Long id,
+    String orderNumber,
+    OrderStatus orderStatus,
+    LocalDateTime orderedAt,
+    int paymentAmount,
+    int totalQuantity,
+    String representativeProductName,
+    String representativeImageUrl,
+    String representativeColor,
+    String representativeSize
+) {}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/entity/OrderStatus.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/entity/OrderStatus.java
@@ -1,12 +1,13 @@
 package com.daebbang.daebbangcore.domain.order.entity;
 
 public enum OrderStatus {
-    PENDING,          // 결제 대기
-    WAITING_DEPOSIT,  // 입금 대기 (가상계좌)
-    PAID,             // 결제 완료
-    IN_DELIVERY,      // 배송중
-    DELIVERED,        // 배송완료
-    COMPLETED,        // 구매확정
-    CANCELLED,        // 취소
-    EXPIRED           // TTL 만료
+    PENDING,              // 결제 대기
+    WAITING_DEPOSIT,      // 입금 대기 (가상계좌)
+    PAID,                 // 결제 완료
+    PREPARING_DELIVERY,   // 배송준비중 (관리자 출고처리 후)
+    IN_DELIVERY,          // 배송중
+    DELIVERED,            // 배송완료
+    COMPLETED,            // 구매확정
+    CANCELLED,            // 취소
+    EXPIRED               // TTL 만료
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/entity/Orders.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/entity/Orders.java
@@ -58,6 +58,7 @@ public class Orders extends DefaultBase {
     private Integer paymentAmount;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @jakarta.persistence.OrderBy("id ASC")
     private final List<OrderDetails> orderList = new ArrayList<>();
 
     @Builder

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/entity/Orders.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/entity/Orders.java
@@ -100,8 +100,13 @@ public class Orders extends DefaultBase {
         this.orderStatus = OrderStatus.WAITING_DEPOSIT;
     }
 
-    public void startDelivery() {
+    public void prepareDelivery() {
         requireStatus(OrderStatus.PAID);
+        this.orderStatus = OrderStatus.PREPARING_DELIVERY;
+    }
+
+    public void startDelivery() {
+        requireStatus(OrderStatus.PREPARING_DELIVERY);
         this.orderStatus = OrderStatus.IN_DELIVERY;
     }
 
@@ -116,7 +121,7 @@ public class Orders extends DefaultBase {
     }
 
     public void cancel() {
-        requireStatus(OrderStatus.PENDING, OrderStatus.WAITING_DEPOSIT, OrderStatus.PAID);
+        requireStatus(OrderStatus.PENDING, OrderStatus.WAITING_DEPOSIT, OrderStatus.PAID, OrderStatus.PREPARING_DELIVERY);
         this.orderStatus = OrderStatus.CANCELLED;
     }
 

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/event/StockInvalidateEvent.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/event/StockInvalidateEvent.java
@@ -1,21 +1,12 @@
 package com.daebbang.daebbangcore.domain.order.event;
 
 import java.util.List;
+import java.util.Objects;
 
-/**
- * 주문 취소 시 발행되는 이벤트.
- * @TransactionalEventListener(AFTER_COMMIT) 으로 소비 → 커밋 확정 후에만 Redis 캐시 무효화.
- * 트랜잭션 롤백 시에는 실행되지 않으므로 DB/Redis 정합성이 보장됨.
- */
-public class StockInvalidateEvent {
+public record StockInvalidateEvent(List<Long> productDetailIds) {
 
-    private final List<Long> productDetailIds;
-
-    public StockInvalidateEvent(List<Long> productDetailIds) {
-        this.productDetailIds = productDetailIds;
-    }
-
-    public List<Long> getProductDetailIds() {
-        return productDetailIds;
+    public StockInvalidateEvent {
+        Objects.requireNonNull(productDetailIds, "productDetailIds must not be null");
+        productDetailIds = List.copyOf(productDetailIds);
     }
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/event/StockInvalidateEvent.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/event/StockInvalidateEvent.java
@@ -1,0 +1,21 @@
+package com.daebbang.daebbangcore.domain.order.event;
+
+import java.util.List;
+
+/**
+ * 주문 취소 시 발행되는 이벤트.
+ * @TransactionalEventListener(AFTER_COMMIT) 으로 소비 → 커밋 확정 후에만 Redis 캐시 무효화.
+ * 트랜잭션 롤백 시에는 실행되지 않으므로 DB/Redis 정합성이 보장됨.
+ */
+public class StockInvalidateEvent {
+
+    private final List<Long> productDetailIds;
+
+    public StockInvalidateEvent(List<Long> productDetailIds) {
+        this.productDetailIds = productDetailIds;
+    }
+
+    public List<Long> getProductDetailIds() {
+        return productDetailIds;
+    }
+}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/OrdersRepository.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/OrdersRepository.java
@@ -1,12 +1,14 @@
 package com.daebbang.daebbangcore.domain.order.repository;
 
 import com.daebbang.daebbangcore.domain.order.entity.Orders;
+import com.daebbang.daebbangcore.domain.order.repository.dsl.OrderCustomRepository;
 import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface OrdersRepository extends JpaRepository<@NonNull Orders, @NonNull Long> {
+public interface OrdersRepository extends JpaRepository<@NonNull Orders, @NonNull Long>,
+    OrderCustomRepository {
 
     boolean existsByOrderNumber(String orderNumber);
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/PaymentRepository.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/PaymentRepository.java
@@ -1,9 +1,14 @@
 package com.daebbang.daebbangcore.domain.order.repository;
 
+import com.daebbang.daebbangcore.domain.order.entity.Orders;
 import com.daebbang.daebbangcore.domain.order.entity.Payment;
+import java.util.Optional;
 import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PaymentRepository extends JpaRepository<@NonNull Payment, @NonNull Long> {}
+public interface PaymentRepository extends JpaRepository<@NonNull Payment, @NonNull Long> {
+
+    Optional<Payment> findByOrder(Orders order);
+}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/dsl/OrderCustomRepository.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/dsl/OrderCustomRepository.java
@@ -1,0 +1,30 @@
+package com.daebbang.daebbangcore.domain.order.repository.dsl;
+
+import com.daebbang.daebbangcore.domain.order.dto.OrderStatusCountResult;
+import com.daebbang.daebbangcore.domain.order.entity.Orders;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface OrderCustomRepository {
+
+    /**
+     * 기간 내 주문 목록 페이징 조회
+     * - 1단계(ID 페이징) + 2단계(fetch join) 분리로 in-memory 페이징 방지
+     */
+    Page<Orders> findOrdersByUserIdAndDateRange(Long userId, LocalDateTime start,
+                                                LocalDateTime end, Pageable pageable);
+
+    /**
+     * 주문 상세 조회 (orderList + productDetail + product fetch join)
+     * - 취소 API / 상세 조회 API 공통 사용
+     */
+    Optional<Orders> findOrderDetailByOrderNumberAndUserId(String orderNumber, Long userId);
+
+    /**
+     * 기간 내 배송 현황 건수 (결제완료 / 배송준비중 / 배송중 / 배송완료)
+     */
+    OrderStatusCountResult countOrderStatusByUserIdAndDateRange(Long userId, LocalDateTime start,
+                                                                LocalDateTime end);
+}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/dsl/impl/OrderCustomRepositoryImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/dsl/impl/OrderCustomRepositoryImpl.java
@@ -4,8 +4,13 @@ import com.daebbang.daebbangcore.domain.order.dto.OrderStatusCountResult;
 import com.daebbang.daebbangcore.domain.order.entity.OrderStatus;
 import com.daebbang.daebbangcore.domain.order.entity.Orders;
 import com.daebbang.daebbangcore.domain.order.repository.dsl.OrderCustomRepository;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -13,8 +18,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import static com.daebbang.daebbangcore.domain.order.entity.QOrderDetails.orderDetails;
@@ -28,15 +34,10 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    /**
-     * 2단계 쿼리로 컬렉션 fetch join + 페이징 충돌 방지.
-     * 1단계: 주문 ID만 페이징 조회 (row 뻥튀기 없음)
-     * 2단계: ID로 LEFT JOIN FETCH (orderList 없어도 주문은 포함)
-     */
     @Override
     public Page<Orders> findOrdersByUserIdAndDateRange(Long userId, LocalDateTime start,
                                                        LocalDateTime end, Pageable pageable) {
-        // 1단계: ID 페이징
+        // 1단계: ID만 페이징 (컬렉션 fetch join 없이 row 뻥튀기 방지)
         List<Long> ids = queryFactory
             .select(orders.id)
             .from(orders)
@@ -44,36 +45,56 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
                 orders.user.id.eq(userId),
                 orders.createdAt.between(start, end)
             )
-            .orderBy(orders.createdAt.desc())
+            .orderBy(toOrderSpecifiers(pageable.getSort()))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
 
         if (ids.isEmpty()) {
-            return Page.empty(pageable);
+            // totalElements를 정확하게 계산하기 위해 count 쿼리 위임
+            JPAQuery<Long> countQuery = queryFactory
+                .select(orders.count())
+                .from(orders)
+                .where(
+                    orders.user.id.eq(userId),
+                    orders.createdAt.between(start, end)
+                );
+            return PageableExecutionUtils.getPage(List.of(), pageable, countQuery::fetchOne);
         }
 
-        Long total = queryFactory
-            .select(orders.count())
-            .from(orders)
-            .where(
-                orders.user.id.eq(userId),
-                orders.createdAt.between(start, end)
-            )
-            .fetchOne();
-
-        // 2단계: ID로 fetch join (left join → orderList 비어도 주문 포함)
+        // 2단계: ID로 LEFT JOIN FETCH (orderList 없어도 주문 포함)
         List<Orders> content = queryFactory
             .selectFrom(orders)
             .leftJoin(orders.orderList, orderDetails).fetchJoin()
             .leftJoin(orderDetails.productDetail, productDetails).fetchJoin()
             .leftJoin(productDetails.product, products).fetchJoin()
             .where(orders.id.in(ids))
-            .orderBy(orders.createdAt.desc())
+            .orderBy(toOrderSpecifiers(pageable.getSort()))
             .distinct()
             .fetch();
 
-        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+        JPAQuery<Long> countQuery = queryFactory
+            .select(orders.count())
+            .from(orders)
+            .where(
+                orders.user.id.eq(userId),
+                orders.createdAt.between(start, end)
+            );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private OrderSpecifier<?>[] toOrderSpecifiers(Sort sort) {
+        if (sort.isUnsorted()) {
+            return new OrderSpecifier[]{orders.createdAt.desc()};
+        }
+        List<OrderSpecifier<?>> specifiers = new ArrayList<>();
+        PathBuilder<Orders> path = new PathBuilder<>(Orders.class, "orders");
+        for (Sort.Order o : sort) {
+            Order direction = o.isAscending() ? Order.ASC : Order.DESC;
+            specifiers.add(new OrderSpecifier<>(direction, path.get(o.getProperty(), Comparable.class)));
+        }
+        return specifiers.toArray(new OrderSpecifier[0]);
     }
 
     @Override
@@ -93,6 +114,11 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
         return Optional.ofNullable(result);
     }
 
+    private static final List<OrderStatus> DELIVERY_STATUSES = List.of(
+        OrderStatus.PAID, OrderStatus.PREPARING_DELIVERY,
+        OrderStatus.IN_DELIVERY, OrderStatus.DELIVERED
+    );
+
     @Override
     public OrderStatusCountResult countOrderStatusByUserIdAndDateRange(Long userId,
                                                                        LocalDateTime start,
@@ -102,7 +128,8 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
             .from(orders)
             .where(
                 orders.user.id.eq(userId),
-                orders.createdAt.between(start, end)
+                orders.createdAt.between(start, end),
+                orders.orderStatus.in(DELIVERY_STATUSES)
             )
             .groupBy(orders.orderStatus)
             .fetch()

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/dsl/impl/OrderCustomRepositoryImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/dsl/impl/OrderCustomRepositoryImpl.java
@@ -6,7 +6,7 @@ import com.daebbang.daebbangcore.domain.order.entity.Orders;
 import com.daebbang.daebbangcore.domain.order.repository.dsl.OrderCustomRepository;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
@@ -31,6 +31,10 @@ import static com.daebbang.daebbangcore.domain.product.entity.QProducts.products
 @Repository
 @RequiredArgsConstructor
 public class OrderCustomRepositoryImpl implements OrderCustomRepository {
+
+    private static final Map<String, ComparableExpressionBase<?>> ORDER_SORTS = Map.of(
+        "createdAt", orders.createdAt
+    );
 
     private final JPAQueryFactory queryFactory;
 
@@ -84,16 +88,22 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private OrderSpecifier<?>[] toOrderSpecifiers(Sort sort) {
         if (sort.isUnsorted()) {
-            return new OrderSpecifier[]{orders.createdAt.desc()};
+            return new OrderSpecifier[]{orders.createdAt.desc(), orders.id.desc()};
         }
         List<OrderSpecifier<?>> specifiers = new ArrayList<>();
-        PathBuilder<Orders> path = new PathBuilder<>(Orders.class, "orders");
         for (Sort.Order o : sort) {
+            ComparableExpressionBase<?> path = ORDER_SORTS.get(o.getProperty());
+            if (path == null) continue;
             Order direction = o.isAscending() ? Order.ASC : Order.DESC;
-            specifiers.add(new OrderSpecifier<>(direction, path.get(o.getProperty(), Comparable.class)));
+            specifiers.add(new OrderSpecifier(direction, path));
         }
+        if (specifiers.isEmpty()) {
+            return new OrderSpecifier[]{orders.createdAt.desc(), orders.id.desc()};
+        }
+        specifiers.add(new OrderSpecifier(Order.DESC, orders.id));
         return specifiers.toArray(new OrderSpecifier[0]);
     }
 

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/dsl/impl/OrderCustomRepositoryImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/repository/dsl/impl/OrderCustomRepositoryImpl.java
@@ -1,0 +1,122 @@
+package com.daebbang.daebbangcore.domain.order.repository.dsl.impl;
+
+import com.daebbang.daebbangcore.domain.order.dto.OrderStatusCountResult;
+import com.daebbang.daebbangcore.domain.order.entity.OrderStatus;
+import com.daebbang.daebbangcore.domain.order.entity.Orders;
+import com.daebbang.daebbangcore.domain.order.repository.dsl.OrderCustomRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import static com.daebbang.daebbangcore.domain.order.entity.QOrderDetails.orderDetails;
+import static com.daebbang.daebbangcore.domain.order.entity.QOrders.orders;
+import static com.daebbang.daebbangcore.domain.product.entity.QProductDetails.productDetails;
+import static com.daebbang.daebbangcore.domain.product.entity.QProducts.products;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderCustomRepositoryImpl implements OrderCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 2단계 쿼리로 컬렉션 fetch join + 페이징 충돌 방지.
+     * 1단계: 주문 ID만 페이징 조회 (row 뻥튀기 없음)
+     * 2단계: ID로 LEFT JOIN FETCH (orderList 없어도 주문은 포함)
+     */
+    @Override
+    public Page<Orders> findOrdersByUserIdAndDateRange(Long userId, LocalDateTime start,
+                                                       LocalDateTime end, Pageable pageable) {
+        // 1단계: ID 페이징
+        List<Long> ids = queryFactory
+            .select(orders.id)
+            .from(orders)
+            .where(
+                orders.user.id.eq(userId),
+                orders.createdAt.between(start, end)
+            )
+            .orderBy(orders.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        if (ids.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        Long total = queryFactory
+            .select(orders.count())
+            .from(orders)
+            .where(
+                orders.user.id.eq(userId),
+                orders.createdAt.between(start, end)
+            )
+            .fetchOne();
+
+        // 2단계: ID로 fetch join (left join → orderList 비어도 주문 포함)
+        List<Orders> content = queryFactory
+            .selectFrom(orders)
+            .leftJoin(orders.orderList, orderDetails).fetchJoin()
+            .leftJoin(orderDetails.productDetail, productDetails).fetchJoin()
+            .leftJoin(productDetails.product, products).fetchJoin()
+            .where(orders.id.in(ids))
+            .orderBy(orders.createdAt.desc())
+            .distinct()
+            .fetch();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    @Override
+    public Optional<Orders> findOrderDetailByOrderNumberAndUserId(String orderNumber, Long userId) {
+        Orders result = queryFactory
+            .selectFrom(orders)
+            .leftJoin(orders.orderList, orderDetails).fetchJoin()
+            .leftJoin(orderDetails.productDetail, productDetails).fetchJoin()
+            .leftJoin(productDetails.product, products).fetchJoin()
+            .where(
+                orders.orderNumber.eq(orderNumber),
+                orders.user.id.eq(userId)
+            )
+            .distinct()
+            .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public OrderStatusCountResult countOrderStatusByUserIdAndDateRange(Long userId,
+                                                                       LocalDateTime start,
+                                                                       LocalDateTime end) {
+        Map<OrderStatus, Long> countMap = queryFactory
+            .select(orders.orderStatus, orders.count())
+            .from(orders)
+            .where(
+                orders.user.id.eq(userId),
+                orders.createdAt.between(start, end)
+            )
+            .groupBy(orders.orderStatus)
+            .fetch()
+            .stream()
+            .collect(Collectors.toMap(
+                tuple -> Objects.requireNonNull(tuple.get(orders.orderStatus)),
+                tuple -> Objects.requireNonNull(tuple.get(orders.count()))
+            ));
+
+        return new OrderStatusCountResult(
+            countMap.getOrDefault(OrderStatus.PAID, 0L),
+            countMap.getOrDefault(OrderStatus.PREPARING_DELIVERY, 0L),
+            countMap.getOrDefault(OrderStatus.IN_DELIVERY, 0L),
+            countMap.getOrDefault(OrderStatus.DELIVERED, 0L)
+        );
+    }
+}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/OrderService.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/OrderService.java
@@ -1,12 +1,32 @@
 package com.daebbang.daebbangcore.domain.order.service;
 
+import com.daebbang.daebbangcore.domain.order.command.OrderCancelCommand;
 import com.daebbang.daebbangcore.domain.order.command.OrderConfirmCommand;
+import com.daebbang.daebbangcore.domain.order.command.OrderPartialCancelCommand;
 import com.daebbang.daebbangcore.domain.order.command.OrderPrepareCommand;
+import com.daebbang.daebbangcore.domain.order.dto.OrderFullDetailResult;
 import com.daebbang.daebbangcore.domain.order.dto.OrderPrepareResponse;
+import com.daebbang.daebbangcore.domain.order.dto.OrderStatusCountResult;
+import com.daebbang.daebbangcore.domain.order.dto.OrderSummaryResult;
+import java.time.LocalDateTime;
+import lombok.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderService {
 
     OrderPrepareResponse prepare(OrderPrepareCommand command);
 
     void confirm(OrderConfirmCommand command);
+
+    void cancel(OrderCancelCommand command);
+
+    void cancelPartial(OrderPartialCancelCommand command);
+
+    Page<@NonNull OrderSummaryResult> getOrderList(Long userId, LocalDateTime start, LocalDateTime end,
+                                          Pageable pageable);
+
+    OrderFullDetailResult getOrderDetail(Long userId, String orderNumber);
+
+    OrderStatusCountResult getOrderStatusCount(Long userId, LocalDateTime start, LocalDateTime end);
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/PaymentService.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/PaymentService.java
@@ -1,0 +1,18 @@
+package com.daebbang.daebbangcore.domain.order.service;
+
+import com.daebbang.daebbangcore.domain.order.entity.Orders;
+import com.daebbang.daebbangcore.domain.order.entity.Payment;
+
+public interface PaymentService {
+
+    void save(Payment payment);
+
+    Payment findByOrder(Orders order);
+
+    /**
+     * 결제 취소 이력 기록 (전액 / 부분 취소 공통)
+     * - PaymentCancels 생성 후 Payment.addCancel() 호출
+     * - totalCancelAmount 갱신 및 PaymentStatus 변경 포함
+     */
+    void recordCancel(Payment payment, String cancelReason, int cancelAmount);
+}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/StockCacheService.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/StockCacheService.java
@@ -2,13 +2,15 @@ package com.daebbang.daebbangcore.domain.order.service;
 
 import com.daebbang.daebbangcommon.error.BusinessException;
 import com.daebbang.daebbangcommon.error.UserErrorCode;
+import com.daebbang.daebbangcore.domain.order.event.StockInvalidateEvent;
 import com.daebbang.daebbangcore.domain.product.service.ProductDetailsService;
-
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Service
@@ -56,5 +58,20 @@ public class StockCacheService {
     public void invalidateStock(Long productDetailId) {
         stringRedisTemplate.delete(STOCK_KEY_PREFIX + productDetailId);
         log.info("[Stock] 캐시 무효화 - productDetailId: {}", productDetailId);
+    }
+
+    /**
+     * 주문 취소 트랜잭션 커밋 완료 후 Redis 캐시 무효화.
+     * AFTER_COMMIT 을 사용하므로 트랜잭션 롤백 시에는 실행되지 않아 DB/Redis 정합성 보장.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockInvalidate(StockInvalidateEvent event) {
+        event.getProductDetailIds().forEach(id -> {
+            try {
+                invalidateStock(id);
+            } catch (Exception e) {
+                log.error("[Stock] 취소 후 캐시 무효화 실패 - productDetailId: {} (다음 요청 시 DB 재로드)", id, e);
+            }
+        });
     }
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/StockCacheService.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/StockCacheService.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -61,12 +62,14 @@ public class StockCacheService {
     }
 
     /**
-     * 주문 취소 트랜잭션 커밋 완료 후 Redis 캐시 무효화.
-     * AFTER_COMMIT 을 사용하므로 트랜잭션 롤백 시에는 실행되지 않아 DB/Redis 정합성 보장.
+     * 주문 취소 트랜잭션 커밋 완료 후 Redis 캐시 비동기 무효화.
+     * AFTER_COMMIT + @Async → 커밋 확정 후 별도 스레드에서 실행.
+     * 트랜잭션 롤백 시에는 실행되지 않아 DB/Redis 정합성 보장.
      */
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleStockInvalidate(StockInvalidateEvent event) {
-        event.getProductDetailIds().forEach(id -> {
+        event.productDetailIds().forEach(id -> {
             try {
                 invalidateStock(id);
             } catch (Exception e) {

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
@@ -25,7 +25,6 @@ import com.daebbang.daebbangcore.domain.order.session.OrderSession;
 import com.daebbang.daebbangcore.domain.order.session.OrderSessionItem;
 import com.daebbang.daebbangcore.domain.order.session.OrderSessionRedisRepository;
 import com.daebbang.daebbangcore.domain.order.session.OrderStockReserveRedisRepository;
-import com.daebbang.daebbangcore.domain.product.entity.DiscountType;
 import com.daebbang.daebbangcore.domain.product.entity.ProductDetails;
 import com.daebbang.daebbangcore.domain.product.entity.Products;
 import com.daebbang.daebbangcore.domain.product.service.ProductDetailsService;
@@ -33,6 +32,7 @@ import com.daebbang.daebbangcore.domain.user.entity.Users;
 import com.daebbang.daebbangcore.domain.user.service.UserService;
 import com.daebbang.daebbangcore.infra.toss.TossPaymentClient;
 import com.daebbang.daebbangcore.infra.toss.dto.TossPaymentResponse;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
@@ -50,6 +51,7 @@ import org.redisson.api.RedissonClient;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -64,6 +66,8 @@ public class OrderServiceImpl implements OrderService {
 
     private static final int FREE_SHIPPING_THRESHOLD = 50_000;
     private static final int DEFAULT_SHIPPING_FEE = 3_000;
+    private static final String CANCEL_IDEMPOTENCY_PREFIX = "order:cancel:idempotency:";
+    private static final Duration CANCEL_IDEMPOTENCY_TTL = Duration.ofHours(24);
 
     private final UserService userService;
     private final ProductDetailsService productDetailsService;
@@ -76,6 +80,7 @@ public class OrderServiceImpl implements OrderService {
     private final OrderStockReserveRedisRepository stockReserveRedisRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final PlatformTransactionManager transactionManager;
+    private final StringRedisTemplate stringRedisTemplate;
 
     // read tx: 검증 단계에서 커넥션 조기 반환
     private TransactionTemplate readTx() {
@@ -275,7 +280,7 @@ public class OrderServiceImpl implements OrderService {
             } catch (Exception e) {
                 log.error("[Order] DB 처리 실패 - Toss 취소 시도 - orderNumber: {}", command.orderNumber(), e);
                 try {
-                    tossPaymentClient.cancel(command.paymentKey(), "시스템 오류로 인한 자동 취소");
+                    tossPaymentClient.cancel(command.paymentKey(), "시스템 오류로 인한 자동 취소", UUID.randomUUID().toString());
                 } catch (Exception cancelEx) {
                     log.error("[Order] Toss 취소 실패 - 수동 취소 필요 - paymentKey: {}", command.paymentKey(), cancelEx);
                 }
@@ -301,16 +306,9 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     public void cancel(OrderCancelCommand command) {
-        RLock cancelLock = redissonClient.getLock("order:cancel:lock:" + command.orderNumber());
-        boolean acquired = false;
-        try {
-            acquired = cancelLock.tryLock(3, TimeUnit.SECONDS);
-            if (!acquired) {
-                throw new BusinessException(UserErrorCode.ORDER_ALREADY_PROCESSED);
-            }
-
+        withCancelLock(command.orderNumber(), () -> {
             // [Phase 1] read tx: 검증 + 필요 데이터 수집 후 커넥션 반환
-            CancelPrecheck precheck = readTx().execute(status -> {
+            CancelPrecheck precheck = Objects.requireNonNull(readTx().execute(status -> {
                 Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
                         command.orderNumber(), command.userId())
                     .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
@@ -328,10 +326,11 @@ public class OrderServiceImpl implements OrderService {
                 }
 
                 return new CancelPrecheck(payment.getPaymentKey(), cancelableAmount);
-            });
+            }));
 
             // [Phase 2] Toss API 호출 — DB 커넥션 미보유
-            tossPaymentClient.cancel(precheck.paymentKey(), command.cancelReason());
+            String idempotencyKey = getOrCreateCancelIdempotencyKey(command.orderNumber());
+            tossPaymentClient.cancel(precheck.paymentKey(), command.cancelReason(), idempotencyKey);
 
             // [Phase 3] write tx: DB 상태 반영
             writeTx().execute(status -> {
@@ -350,47 +349,22 @@ public class OrderServiceImpl implements OrderService {
                 }
                 order.cancel();
                 paymentService.recordCancel(payment, command.cancelReason(), precheck.cancelableAmount());
-
-                for (OrderDetails detail : cancelTargets) {
-                    int updated = productDetailsService.increaseStock(
-                        detail.getProductDetail().getId(), detail.getQuantity()
-                    );
-                    if (updated != 1) {
-                        log.error("[Order] 재고 복원 실패 - productDetailId: {}", detail.getProductDetail().getId());
-                        throw new BusinessException(UserErrorCode.STOCK_RESTORE_FAILED);
-                    }
-                }
-
-                List<Long> productDetailIds = cancelTargets.stream()
-                    .map(d -> d.getProductDetail().getId())
-                    .toList();
-                eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+                restoreStockAndPublishEvent(cancelTargets);
 
                 log.info("[Order] 전체 취소 완료 - orderNumber: {}, userId: {}",
                     command.orderNumber(), command.userId());
                 return null;
             });
 
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new BusinessException(UserErrorCode.ORDER_ALREADY_PROCESSED);
-        } finally {
-            if (acquired) cancelLock.unlock();
-        }
+            deleteCancelIdempotencyKey(command.orderNumber());
+        });
     }
 
     @Override
     public void cancelPartial(OrderPartialCancelCommand command) {
-        RLock cancelLock = redissonClient.getLock("order:cancel:lock:" + command.orderNumber());
-        boolean acquired = false;
-        try {
-            acquired = cancelLock.tryLock(3, TimeUnit.SECONDS);
-            if (!acquired) {
-                throw new BusinessException(UserErrorCode.ORDER_ALREADY_PROCESSED);
-            }
-
+        withCancelLock(command.orderNumber(), () -> {
             // [Phase 1] read tx: 검증 + 필요 데이터 수집
-            PartialCancelPrecheck precheck = readTx().execute(status -> {
+            PartialCancelPrecheck precheck = Objects.requireNonNull(readTx().execute(status -> {
                 Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
                         command.orderNumber(), command.userId())
                     .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
@@ -431,10 +405,11 @@ public class OrderServiceImpl implements OrderService {
 
                 List<Long> targetDetailIds = targetDetails.stream().map(OrderDetails::getId).toList();
                 return new PartialCancelPrecheck(payment.getPaymentKey(), cancelAmount, targetDetailIds);
-            });
+            }));
 
             // [Phase 2] Toss API 호출 — DB 커넥션 미보유
-            tossPaymentClient.cancel(precheck.paymentKey(), command.cancelReason(), precheck.cancelAmount());
+            String idempotencyKey = getOrCreateCancelIdempotencyKey(command.orderNumber());
+            tossPaymentClient.cancel(precheck.paymentKey(), command.cancelReason(), precheck.cancelAmount(), idempotencyKey);
 
             // [Phase 3] write tx: DB 상태 반영
             writeTx().execute(status -> {
@@ -459,33 +434,15 @@ public class OrderServiceImpl implements OrderService {
                 }
 
                 paymentService.recordCancel(payment, command.cancelReason(), precheck.cancelAmount());
+                restoreStockAndPublishEvent(targetDetails);
 
-                for (OrderDetails detail : targetDetails) {
-                    int updated = productDetailsService.increaseStock(
-                        detail.getProductDetail().getId(), detail.getQuantity()
-                    );
-                    if (updated != 1) {
-                        log.error("[Order] 재고 복원 실패 - productDetailId: {}", detail.getProductDetail().getId());
-                        throw new BusinessException(UserErrorCode.STOCK_RESTORE_FAILED);
-                    }
-                }
-
-                List<Long> productDetailIds = targetDetails.stream()
-                    .map(d -> d.getProductDetail().getId())
-                    .toList();
-                eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
-
-                log.info("[Order] 일부 취소 완료 - orderNumber: {}, userId: {}, 취소금액: {}",
+                log.info("[Order] 부분 취소 완료 - orderNumber: {}, userId: {}, 취소금액: {}",
                     command.orderNumber(), command.userId(), precheck.cancelAmount());
                 return null;
             });
 
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new BusinessException(UserErrorCode.ORDER_ALREADY_PROCESSED);
-        } finally {
-            if (acquired) cancelLock.unlock();
-        }
+            deleteCancelIdempotencyKey(command.orderNumber());
+        });
     }
 
     @Override
@@ -572,6 +529,54 @@ public class OrderServiceImpl implements OrderService {
             }
             default -> 0;
         };
+    }
+
+    private void withCancelLock(String orderNumber, Runnable action) {
+        RLock cancelLock = redissonClient.getLock("order:cancel:lock:" + orderNumber);
+        boolean acquired = false;
+        try {
+            acquired = cancelLock.tryLock(3, TimeUnit.SECONDS);
+            if (!acquired) {
+                throw new BusinessException(UserErrorCode.ORDER_ALREADY_PROCESSED);
+            }
+            action.run();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException(UserErrorCode.ORDER_ALREADY_PROCESSED);
+        } finally {
+            if (acquired) cancelLock.unlock();
+        }
+    }
+
+    private void restoreStockAndPublishEvent(List<OrderDetails> details) {
+        for (OrderDetails detail : details) {
+            int updated = productDetailsService.increaseStock(
+                detail.getProductDetail().getId(), detail.getQuantity()
+            );
+            if (updated != 1) {
+                log.error("[Order] 재고 복원 실패 - productDetailId: {}", detail.getProductDetail().getId());
+                throw new BusinessException(UserErrorCode.STOCK_RESTORE_FAILED);
+            }
+        }
+        List<Long> productDetailIds = details.stream()
+            .map(d -> d.getProductDetail().getId())
+            .toList();
+        eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+    }
+
+    private String getOrCreateCancelIdempotencyKey(String orderNumber) {
+        String redisKey = CANCEL_IDEMPOTENCY_PREFIX + orderNumber;
+        String existing = stringRedisTemplate.opsForValue().get(redisKey);
+        if (existing != null) {
+            return existing;
+        }
+        String newKey = UUID.randomUUID().toString();
+        stringRedisTemplate.opsForValue().set(redisKey, newKey, CANCEL_IDEMPOTENCY_TTL);
+        return newKey;
+    }
+
+    private void deleteCancelIdempotencyKey(String orderNumber) {
+        stringRedisTemplate.delete(CANCEL_IDEMPOTENCY_PREFIX + orderNumber);
     }
 
     private String generateOrderNumber() {

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
@@ -301,161 +301,191 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     public void cancel(OrderCancelCommand command) {
-        // [Phase 1] read tx: 검증 + 필요 데이터 수집 후 커넥션 반환
-        CancelPrecheck precheck = readTx().execute(status -> {
-            Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
-                    command.orderNumber(), command.userId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
-
-            if (order.getOrderStatus() != OrderStatus.PAID
-                && order.getOrderStatus() != OrderStatus.WAITING_DEPOSIT
-                && order.getOrderStatus() != OrderStatus.PREPARING_DELIVERY) {
-                throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+        RLock cancelLock = redissonClient.getLock("order:cancel:lock:" + command.orderNumber());
+        boolean acquired = false;
+        try {
+            acquired = cancelLock.tryLock(3, TimeUnit.SECONDS);
+            if (!acquired) {
+                throw new BusinessException(UserErrorCode.ORDER_ALREADY_PROCESSED);
             }
 
-            Payment payment = paymentService.findByOrder(order);
-            int cancelableAmount = payment.getTotalAmount() - payment.getTotalCancelAmount();
-            if (cancelableAmount <= 0) {
-                throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
-            }
+            // [Phase 1] read tx: 검증 + 필요 데이터 수집 후 커넥션 반환
+            CancelPrecheck precheck = readTx().execute(status -> {
+                Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
+                        command.orderNumber(), command.userId())
+                    .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
 
-            return new CancelPrecheck(payment.getPaymentKey(), cancelableAmount);
-        });
-
-        // [Phase 2] Toss API 호출 — DB 커넥션 미보유
-        tossPaymentClient.cancel(precheck.paymentKey(), command.cancelReason());
-
-        // [Phase 3] write tx: DB 상태 반영
-        writeTx().execute(status -> {
-            Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
-                    command.orderNumber(), command.userId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
-            Payment payment = paymentService.findByOrder(order);
-
-            List<OrderDetails> cancelTargets = order.getOrderList().stream()
-                .filter(d -> d.getStatus() == OrderDetailStatus.NORMAL)
-                .toList();
-
-            for (OrderDetails detail : cancelTargets) {
-                detail.cancelRequest();
-                detail.cancel();
-            }
-            order.cancel();
-            paymentService.recordCancel(payment, command.cancelReason(), precheck.cancelableAmount());
-
-            for (OrderDetails detail : cancelTargets) {
-                int updated = productDetailsService.increaseStock(
-                    detail.getProductDetail().getId(), detail.getQuantity()
-                );
-                if (updated != 1) {
-                    log.error("[Order] 재고 복원 실패 - productDetailId: {}", detail.getProductDetail().getId());
-                    throw new BusinessException(UserErrorCode.STOCK_RESTORE_FAILED);
+                if (order.getOrderStatus() != OrderStatus.PAID
+                    && order.getOrderStatus() != OrderStatus.WAITING_DEPOSIT
+                    && order.getOrderStatus() != OrderStatus.PREPARING_DELIVERY) {
+                    throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
                 }
-            }
 
-            List<Long> productDetailIds = cancelTargets.stream()
-                .map(d -> d.getProductDetail().getId())
-                .toList();
-            eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+                Payment payment = paymentService.findByOrder(order);
+                int cancelableAmount = payment.getTotalAmount() - payment.getTotalCancelAmount();
+                if (cancelableAmount <= 0) {
+                    throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+                }
 
-            log.info("[Order] 전체 취소 완료 - orderNumber: {}, userId: {}",
-                command.orderNumber(), command.userId());
-            return null;
-        });
+                return new CancelPrecheck(payment.getPaymentKey(), cancelableAmount);
+            });
+
+            // [Phase 2] Toss API 호출 — DB 커넥션 미보유
+            tossPaymentClient.cancel(precheck.paymentKey(), command.cancelReason());
+
+            // [Phase 3] write tx: DB 상태 반영
+            writeTx().execute(status -> {
+                Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
+                        command.orderNumber(), command.userId())
+                    .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
+                Payment payment = paymentService.findByOrder(order);
+
+                List<OrderDetails> cancelTargets = order.getOrderList().stream()
+                    .filter(d -> d.getStatus() == OrderDetailStatus.NORMAL)
+                    .toList();
+
+                for (OrderDetails detail : cancelTargets) {
+                    detail.cancelRequest();
+                    detail.cancel();
+                }
+                order.cancel();
+                paymentService.recordCancel(payment, command.cancelReason(), precheck.cancelableAmount());
+
+                for (OrderDetails detail : cancelTargets) {
+                    int updated = productDetailsService.increaseStock(
+                        detail.getProductDetail().getId(), detail.getQuantity()
+                    );
+                    if (updated != 1) {
+                        log.error("[Order] 재고 복원 실패 - productDetailId: {}", detail.getProductDetail().getId());
+                        throw new BusinessException(UserErrorCode.STOCK_RESTORE_FAILED);
+                    }
+                }
+
+                List<Long> productDetailIds = cancelTargets.stream()
+                    .map(d -> d.getProductDetail().getId())
+                    .toList();
+                eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+
+                log.info("[Order] 전체 취소 완료 - orderNumber: {}, userId: {}",
+                    command.orderNumber(), command.userId());
+                return null;
+            });
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException(UserErrorCode.ORDER_ALREADY_PROCESSED);
+        } finally {
+            if (acquired) cancelLock.unlock();
+        }
     }
 
     @Override
     public void cancelPartial(OrderPartialCancelCommand command) {
-        // [Phase 1] read tx: 검증 + 필요 데이터 수집
-        PartialCancelPrecheck precheck = readTx().execute(status -> {
-            Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
-                    command.orderNumber(), command.userId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
-
-            if (order.getOrderStatus() != OrderStatus.PAID
-                && order.getOrderStatus() != OrderStatus.PREPARING_DELIVERY) {
-                throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+        RLock cancelLock = redissonClient.getLock("order:cancel:lock:" + command.orderNumber());
+        boolean acquired = false;
+        try {
+            acquired = cancelLock.tryLock(3, TimeUnit.SECONDS);
+            if (!acquired) {
+                throw new BusinessException(UserErrorCode.ORDER_ALREADY_PROCESSED);
             }
 
-            List<Long> targetIds = command.orderDetailIds();
-            List<OrderDetails> targetDetails = order.getOrderList().stream()
-                .filter(d -> targetIds.contains(d.getId()))
-                .toList();
+            // [Phase 1] read tx: 검증 + 필요 데이터 수집
+            PartialCancelPrecheck precheck = readTx().execute(status -> {
+                Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
+                        command.orderNumber(), command.userId())
+                    .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
 
-            if (targetDetails.size() != targetIds.size()) {
-                throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
-            }
-            if (targetDetails.stream().anyMatch(d -> d.getStatus() != OrderDetailStatus.NORMAL)) {
-                throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
-            }
-
-            int cancelAmount = targetDetails.stream()
-                .mapToInt(OrderDetails::getDiscountPrice)
-                .sum();
-
-            // 모든 항목 취소 시 배송비도 환불
-            boolean allWillBeCancelled = order.getOrderList().stream()
-                .allMatch(d -> targetIds.contains(d.getId()) || d.getStatus() == OrderDetailStatus.CANCELLED);
-            if (allWillBeCancelled) {
-                cancelAmount += order.getShippingFee();
-            }
-
-            Payment payment = paymentService.findByOrder(order);
-            int remainingAmount = payment.getTotalAmount() - payment.getTotalCancelAmount();
-            if (cancelAmount > remainingAmount || cancelAmount <= 0) {
-                throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
-            }
-
-            List<Long> targetDetailIds = targetDetails.stream().map(OrderDetails::getId).toList();
-            return new PartialCancelPrecheck(payment.getPaymentKey(), cancelAmount, targetDetailIds);
-        });
-
-        // [Phase 2] Toss API 호출 — DB 커넥션 미보유
-        tossPaymentClient.cancel(precheck.paymentKey(), command.cancelReason(), precheck.cancelAmount());
-
-        // [Phase 3] write tx: DB 상태 반영
-        writeTx().execute(status -> {
-            Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
-                    command.orderNumber(), command.userId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
-            Payment payment = paymentService.findByOrder(order);
-
-            List<OrderDetails> targetDetails = order.getOrderList().stream()
-                .filter(d -> precheck.targetDetailIds().contains(d.getId()))
-                .toList();
-
-            for (OrderDetails detail : targetDetails) {
-                detail.cancelRequest();
-                detail.cancel();
-            }
-
-            boolean allCancelled = order.getOrderList().stream()
-                .allMatch(d -> d.getStatus() == OrderDetailStatus.CANCELLED);
-            if (allCancelled) {
-                order.cancel();
-            }
-
-            paymentService.recordCancel(payment, command.cancelReason(), precheck.cancelAmount());
-
-            for (OrderDetails detail : targetDetails) {
-                int updated = productDetailsService.increaseStock(
-                    detail.getProductDetail().getId(), detail.getQuantity()
-                );
-                if (updated != 1) {
-                    log.error("[Order] 재고 복원 실패 - productDetailId: {}", detail.getProductDetail().getId());
-                    throw new BusinessException(UserErrorCode.STOCK_RESTORE_FAILED);
+                if (order.getOrderStatus() != OrderStatus.PAID
+                    && order.getOrderStatus() != OrderStatus.PREPARING_DELIVERY) {
+                    throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
                 }
-            }
 
-            List<Long> productDetailIds = targetDetails.stream()
-                .map(d -> d.getProductDetail().getId())
-                .toList();
-            eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+                List<Long> targetIds = command.orderDetailIds();
+                List<OrderDetails> targetDetails = order.getOrderList().stream()
+                    .filter(d -> targetIds.contains(d.getId()))
+                    .toList();
 
-            log.info("[Order] 일부 취소 완료 - orderNumber: {}, userId: {}, 취소금액: {}",
-                command.orderNumber(), command.userId(), precheck.cancelAmount());
-            return null;
-        });
+                if (targetDetails.size() != targetIds.size()) {
+                    throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
+                }
+                if (targetDetails.stream().anyMatch(d -> d.getStatus() != OrderDetailStatus.NORMAL)) {
+                    throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
+                }
+
+                int cancelAmount = targetDetails.stream()
+                    .mapToInt(OrderDetails::getDiscountPrice)
+                    .sum();
+
+                // 모든 항목 취소 시 배송비도 환불
+                boolean allWillBeCancelled = order.getOrderList().stream()
+                    .allMatch(d -> targetIds.contains(d.getId()) || d.getStatus() == OrderDetailStatus.CANCELLED);
+                if (allWillBeCancelled) {
+                    cancelAmount += order.getShippingFee();
+                }
+
+                Payment payment = paymentService.findByOrder(order);
+                int remainingAmount = payment.getTotalAmount() - payment.getTotalCancelAmount();
+                if (cancelAmount > remainingAmount || cancelAmount <= 0) {
+                    throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
+                }
+
+                List<Long> targetDetailIds = targetDetails.stream().map(OrderDetails::getId).toList();
+                return new PartialCancelPrecheck(payment.getPaymentKey(), cancelAmount, targetDetailIds);
+            });
+
+            // [Phase 2] Toss API 호출 — DB 커넥션 미보유
+            tossPaymentClient.cancel(precheck.paymentKey(), command.cancelReason(), precheck.cancelAmount());
+
+            // [Phase 3] write tx: DB 상태 반영
+            writeTx().execute(status -> {
+                Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
+                        command.orderNumber(), command.userId())
+                    .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
+                Payment payment = paymentService.findByOrder(order);
+
+                List<OrderDetails> targetDetails = order.getOrderList().stream()
+                    .filter(d -> precheck.targetDetailIds().contains(d.getId()))
+                    .toList();
+
+                for (OrderDetails detail : targetDetails) {
+                    detail.cancelRequest();
+                    detail.cancel();
+                }
+
+                boolean allCancelled = order.getOrderList().stream()
+                    .allMatch(d -> d.getStatus() == OrderDetailStatus.CANCELLED);
+                if (allCancelled) {
+                    order.cancel();
+                }
+
+                paymentService.recordCancel(payment, command.cancelReason(), precheck.cancelAmount());
+
+                for (OrderDetails detail : targetDetails) {
+                    int updated = productDetailsService.increaseStock(
+                        detail.getProductDetail().getId(), detail.getQuantity()
+                    );
+                    if (updated != 1) {
+                        log.error("[Order] 재고 복원 실패 - productDetailId: {}", detail.getProductDetail().getId());
+                        throw new BusinessException(UserErrorCode.STOCK_RESTORE_FAILED);
+                    }
+                }
+
+                List<Long> productDetailIds = targetDetails.stream()
+                    .map(d -> d.getProductDetail().getId())
+                    .toList();
+                eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+
+                log.info("[Order] 일부 취소 완료 - orderNumber: {}, userId: {}, 취소금액: {}",
+                    command.orderNumber(), command.userId(), precheck.cancelAmount());
+                return null;
+            });
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException(UserErrorCode.ORDER_ALREADY_PROCESSED);
+        } finally {
+            if (acquired) cancelLock.unlock();
+        }
     }
 
     @Override

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
@@ -42,15 +42,18 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
 @Service
@@ -71,6 +74,25 @@ public class OrderServiceImpl implements OrderService {
     private final RedissonClient redissonClient;
     private final OrderStockReserveRedisRepository stockReserveRedisRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final PlatformTransactionManager transactionManager;
+
+    // read tx: 검증 단계에서 커넥션 조기 반환
+    private TransactionTemplate readTx() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        tx.setReadOnly(true);
+        tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return tx;
+    }
+
+    // write tx: Toss 호출 후 DB 반영
+    private TransactionTemplate writeTx() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return tx;
+    }
+
+    private record CancelPrecheck(String paymentKey, int cancelableAmount) {}
+    private record PartialCancelPrecheck(String paymentKey, int cancelAmount, List<Long> targetDetailIds) {}
 
     @Override
     public OrderPrepareResponse prepare(OrderPrepareCommand command) {
@@ -273,134 +295,160 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
-    @Transactional
     public void cancel(OrderCancelCommand command) {
-        // 1. 주문 조회 (userId 포함 → 타인 주문 취소 방지)
-        Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(command.orderNumber(), command.userId())
-            .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
+        // [Phase 1] read tx: 검증 + 필요 데이터 수집 후 커넥션 반환
+        CancelPrecheck precheck = readTx().execute(status -> {
+            Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
+                    command.orderNumber(), command.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
 
-        // 2. 취소 가능 상태 검증 (배송중 이후는 취소 불가 → 반품 프로세스 이용)
-        if (order.getOrderStatus() != OrderStatus.PAID
-            && order.getOrderStatus() != OrderStatus.WAITING_DEPOSIT
-            && order.getOrderStatus() != OrderStatus.PREPARING_DELIVERY) {
-            throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
-        }
-
-        // 3. 결제 조회
-        Payment payment = paymentService.findByOrder(order);
-
-        // 4. Toss 전액 취소 — 실패 시 예외 throw → 트랜잭션 롤백 (DB 변경 없음)
-        tossPaymentClient.cancel(payment.getPaymentKey(), command.cancelReason());
-
-        // 5. NORMAL 상태인 OrderDetails 모두 취소
-        for (OrderDetails detail : order.getOrderList()) {
-            if (detail.getStatus() == OrderDetailStatus.NORMAL) {
-                detail.cancelRequest();
-                detail.cancel();
+            if (order.getOrderStatus() != OrderStatus.PAID
+                && order.getOrderStatus() != OrderStatus.WAITING_DEPOSIT
+                && order.getOrderStatus() != OrderStatus.PREPARING_DELIVERY) {
+                throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
             }
-        }
 
-        // 6. Orders 상태 취소로 변경
-        order.cancel();
+            Payment payment = paymentService.findByOrder(order);
+            int cancelableAmount = payment.getTotalAmount() - payment.getTotalCancelAmount();
+            if (cancelableAmount <= 0) {
+                throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+            }
 
-        // 7. 결제 취소 이력 기록 (전액: 남은 미취소 금액 전부)
-        int remainingAmount = payment.getTotalAmount() - payment.getTotalCancelAmount();
-        paymentService.recordCancel(payment, command.cancelReason(), remainingAmount);
+            return new CancelPrecheck(payment.getPaymentKey(), cancelableAmount);
+        });
 
-        // 8. DB 재고 복원
-        for (OrderDetails detail : order.getOrderList()) {
-            productDetailsService.increaseStock(
-                detail.getProductDetail().getId(), detail.getQuantity()
-            );
-        }
+        // [Phase 2] Toss API 호출 — DB 커넥션 미보유
+        tossPaymentClient.cancel(precheck.paymentKey(), command.cancelReason());
 
-        // 9. 이벤트 발행 → 트랜잭션 커밋 후 Redis 캐시 무효화
-        //    롤백 시에는 AFTER_COMMIT 리스너가 실행되지 않으므로 Redis/DB 정합성 보장
-        List<Long> productDetailIds = order.getOrderList().stream()
-            .map(d -> d.getProductDetail().getId())
-            .toList();
-        eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+        // [Phase 3] write tx: DB 상태 반영
+        writeTx().execute(status -> {
+            Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
+                    command.orderNumber(), command.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
+            Payment payment = paymentService.findByOrder(order);
 
-        log.info("[Order] 전체 취소 완료 - orderNumber: {}, userId: {}",
-            command.orderNumber(), command.userId());
+            for (OrderDetails detail : order.getOrderList()) {
+                if (detail.getStatus() == OrderDetailStatus.NORMAL) {
+                    detail.cancelRequest();
+                    detail.cancel();
+                }
+            }
+            order.cancel();
+            paymentService.recordCancel(payment, command.cancelReason(), precheck.cancelableAmount());
+
+            for (OrderDetails detail : order.getOrderList()) {
+                int updated = productDetailsService.increaseStock(
+                    detail.getProductDetail().getId(), detail.getQuantity()
+                );
+                if (updated != 1) {
+                    log.error("[Order] 재고 복원 실패 - productDetailId: {}", detail.getProductDetail().getId());
+                    throw new BusinessException(UserErrorCode.STOCK_RESTORE_FAILED);
+                }
+            }
+
+            List<Long> productDetailIds = order.getOrderList().stream()
+                .map(d -> d.getProductDetail().getId())
+                .toList();
+            eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+
+            log.info("[Order] 전체 취소 완료 - orderNumber: {}, userId: {}",
+                command.orderNumber(), command.userId());
+            return null;
+        });
     }
 
     @Override
-    @Transactional
     public void cancelPartial(OrderPartialCancelCommand command) {
-        // 1. 주문 조회 (userId 포함 → 타인 주문 취소 방지)
-        Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(command.orderNumber(), command.userId())
-            .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
+        // [Phase 1] read tx: 검증 + 필요 데이터 수집
+        PartialCancelPrecheck precheck = readTx().execute(status -> {
+            Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
+                    command.orderNumber(), command.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
 
-        // 2. 일부 취소는 PAID 상태만 허용 (WAITING_DEPOSIT은 전액 취소만)
-        if (order.getOrderStatus() != OrderStatus.PAID) {
-            throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
-        }
+            if (order.getOrderStatus() != OrderStatus.PAID
+                && order.getOrderStatus() != OrderStatus.PREPARING_DELIVERY) {
+                throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+            }
 
-        // 3. 취소 대상 detail 검증
-        List<Long> targetIds = command.orderDetailIds();
-        if (targetIds == null || targetIds.isEmpty()) {
-            throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
-        }
+            List<Long> targetIds = command.orderDetailIds();
+            List<OrderDetails> targetDetails = order.getOrderList().stream()
+                .filter(d -> targetIds.contains(d.getId()))
+                .toList();
 
-        List<OrderDetails> targetDetails = order.getOrderList().stream()
-            .filter(d -> targetIds.contains(d.getId()))
-            .toList();
+            if (targetDetails.size() != targetIds.size()) {
+                throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
+            }
+            if (targetDetails.stream().anyMatch(d -> d.getStatus() != OrderDetailStatus.NORMAL)) {
+                throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
+            }
 
-        // 요청한 ID 수와 실제 조회 수가 다르면 → 해당 주문에 없는 ID가 포함됨
-        if (targetDetails.size() != targetIds.size()) {
-            throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
-        }
+            int cancelAmount = targetDetails.stream()
+                .mapToInt(OrderDetails::getDiscountPrice)
+                .sum();
 
-        // 이미 취소된 항목이 포함된 경우 거부
-        boolean hasAlreadyCancelled = targetDetails.stream()
-            .anyMatch(d -> d.getStatus() != OrderDetailStatus.NORMAL);
-        if (hasAlreadyCancelled) {
-            throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
-        }
+            // 모든 항목 취소 시 배송비도 환불
+            boolean allWillBeCancelled = order.getOrderList().stream()
+                .allMatch(d -> targetIds.contains(d.getId()) || d.getStatus() == OrderDetailStatus.CANCELLED);
+            if (allWillBeCancelled) {
+                cancelAmount += order.getShippingFee();
+            }
 
-        // 4. 취소 금액 계산 (선택된 detail의 discountPrice 합계)
-        int cancelAmount = targetDetails.stream()
-            .mapToInt(OrderDetails::getDiscountPrice)
-            .sum();
+            Payment payment = paymentService.findByOrder(order);
+            int remainingAmount = payment.getTotalAmount() - payment.getTotalCancelAmount();
+            if (cancelAmount > remainingAmount || cancelAmount <= 0) {
+                throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
+            }
 
-        // 5. 결제 조회
-        Payment payment = paymentService.findByOrder(order);
+            List<Long> targetDetailIds = targetDetails.stream().map(OrderDetails::getId).toList();
+            return new PartialCancelPrecheck(payment.getPaymentKey(), cancelAmount, targetDetailIds);
+        });
 
-        // 6. Toss 부분 취소 — 실패 시 예외 throw → 트랜잭션 롤백 (DB 변경 없음)
-        tossPaymentClient.cancel(payment.getPaymentKey(), command.cancelReason(), cancelAmount);
+        // [Phase 2] Toss API 호출 — DB 커넥션 미보유
+        tossPaymentClient.cancel(precheck.paymentKey(), command.cancelReason(), precheck.cancelAmount());
 
-        // 7. 선택된 detail 취소 처리
-        for (OrderDetails detail : targetDetails) {
-            detail.cancelRequest();
-            detail.cancel();
-        }
+        // [Phase 3] write tx: DB 상태 반영
+        writeTx().execute(status -> {
+            Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(
+                    command.orderNumber(), command.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
+            Payment payment = paymentService.findByOrder(order);
 
-        // 8. 모든 detail이 취소됐으면 Orders도 CANCELLED
-        boolean allCancelled = order.getOrderList().stream()
-            .allMatch(d -> d.getStatus() == OrderDetailStatus.CANCELLED);
-        if (allCancelled) {
-            order.cancel();
-        }
+            List<OrderDetails> targetDetails = order.getOrderList().stream()
+                .filter(d -> precheck.targetDetailIds().contains(d.getId()))
+                .toList();
 
-        // 9. 결제 취소 이력 기록 (부분 취소)
-        paymentService.recordCancel(payment, command.cancelReason(), cancelAmount);
+            for (OrderDetails detail : targetDetails) {
+                detail.cancelRequest();
+                detail.cancel();
+            }
 
-        // 10. 취소된 detail들의 DB 재고 복원
-        for (OrderDetails detail : targetDetails) {
-            productDetailsService.increaseStock(
-                detail.getProductDetail().getId(), detail.getQuantity()
-            );
-        }
+            boolean allCancelled = order.getOrderList().stream()
+                .allMatch(d -> d.getStatus() == OrderDetailStatus.CANCELLED);
+            if (allCancelled) {
+                order.cancel();
+            }
 
-        // 11. 이벤트 발행 → 트랜잭션 커밋 후 Redis 캐시 무효화 (취소된 상품만)
-        List<Long> productDetailIds = targetDetails.stream()
-            .map(d -> d.getProductDetail().getId())
-            .toList();
-        eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+            paymentService.recordCancel(payment, command.cancelReason(), precheck.cancelAmount());
 
-        log.info("[Order] 일부 취소 완료 - orderNumber: {}, userId: {}, 취소금액: {}",
-            command.orderNumber(), command.userId(), cancelAmount);
+            for (OrderDetails detail : targetDetails) {
+                int updated = productDetailsService.increaseStock(
+                    detail.getProductDetail().getId(), detail.getQuantity()
+                );
+                if (updated != 1) {
+                    log.error("[Order] 재고 복원 실패 - productDetailId: {}", detail.getProductDetail().getId());
+                    throw new BusinessException(UserErrorCode.STOCK_RESTORE_FAILED);
+                }
+            }
+
+            List<Long> productDetailIds = targetDetails.stream()
+                .map(d -> d.getProductDetail().getId())
+                .toList();
+            eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+
+            log.info("[Order] 일부 취소 완료 - orderNumber: {}, userId: {}, 취소금액: {}",
+                command.orderNumber(), command.userId(), precheck.cancelAmount());
+            return null;
+        });
     }
 
     @Override

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
@@ -25,6 +25,7 @@ import com.daebbang.daebbangcore.domain.order.session.OrderSession;
 import com.daebbang.daebbangcore.domain.order.session.OrderSessionItem;
 import com.daebbang.daebbangcore.domain.order.session.OrderSessionRedisRepository;
 import com.daebbang.daebbangcore.domain.order.session.OrderStockReserveRedisRepository;
+import com.daebbang.daebbangcore.domain.product.entity.DiscountType;
 import com.daebbang.daebbangcore.domain.product.entity.ProductDetails;
 import com.daebbang.daebbangcore.domain.product.entity.Products;
 import com.daebbang.daebbangcore.domain.product.service.ProductDetailsService;
@@ -101,6 +102,7 @@ public class OrderServiceImpl implements OrderService {
         List<OrderSessionItem> sessionItems = new ArrayList<>();
         Map<Long, Integer> decreasedStocks = new LinkedHashMap<>();
 
+        LocalDate today = LocalDate.now();
         try {
             for (OrderItemCommand item : command.items()) {
                 boolean acquired = false;
@@ -116,8 +118,7 @@ public class OrderServiceImpl implements OrderService {
 
                     ProductDetails pd = productDetailsService.getProductDetailsById(item.productDetailId());
                     Products product = pd.getProduct();
-
-                    int discountRate = product.getDiscountRate() != null ? product.getDiscountRate() : 0;
+                    int discountRate = resolveDiscountRate(product, today);
                     int originalPrice = product.getOriginalPrice();
                     int discountPrice = (int) (originalPrice * (1 - discountRate / 100.0)) * item.quantity();
 
@@ -136,7 +137,7 @@ public class OrderServiceImpl implements OrderService {
                     if (acquired) lock.unlock();
                 }
             }
-        } catch (BusinessException e) {
+        } catch (RuntimeException e) {
             decreasedStocks.forEach(stockCacheService::restoreStock);
             throw e;
         }
@@ -148,6 +149,10 @@ public class OrderServiceImpl implements OrderService {
             .mapToInt(OrderSessionItem::getDiscountPrice)
             .sum();
         int shippingFee = totalSellingAmount >= FREE_SHIPPING_THRESHOLD ? 0 : DEFAULT_SHIPPING_FEE;
+
+        if (command.usedPoint() > totalSellingAmount + shippingFee) {
+            throw new BusinessException(UserErrorCode.POINT_EXCEEDS_PAYMENT);
+        }
         int paymentAmount = totalSellingAmount + shippingFee - command.usedPoint();
 
         String orderNumber = generateOrderNumber();
@@ -327,16 +332,18 @@ public class OrderServiceImpl implements OrderService {
                 .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
             Payment payment = paymentService.findByOrder(order);
 
-            for (OrderDetails detail : order.getOrderList()) {
-                if (detail.getStatus() == OrderDetailStatus.NORMAL) {
-                    detail.cancelRequest();
-                    detail.cancel();
-                }
+            List<OrderDetails> cancelTargets = order.getOrderList().stream()
+                .filter(d -> d.getStatus() == OrderDetailStatus.NORMAL)
+                .toList();
+
+            for (OrderDetails detail : cancelTargets) {
+                detail.cancelRequest();
+                detail.cancel();
             }
             order.cancel();
             paymentService.recordCancel(payment, command.cancelReason(), precheck.cancelableAmount());
 
-            for (OrderDetails detail : order.getOrderList()) {
+            for (OrderDetails detail : cancelTargets) {
                 int updated = productDetailsService.increaseStock(
                     detail.getProductDetail().getId(), detail.getQuantity()
                 );
@@ -346,7 +353,7 @@ public class OrderServiceImpl implements OrderService {
                 }
             }
 
-            List<Long> productDetailIds = order.getOrderList().stream()
+            List<Long> productDetailIds = cancelTargets.stream()
                 .map(d -> d.getProductDetail().getId())
                 .toList();
             eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
@@ -519,6 +526,22 @@ public class OrderServiceImpl implements OrderService {
             order.getPaymentAmount(),
             items
         );
+    }
+
+    private int resolveDiscountRate(Products product, LocalDate today) {
+        if (product.getDiscountRate() == null) return 0;
+        return switch (product.getDiscountType()) {
+            case ALWAYS -> product.getDiscountRate();
+            case PERIOD -> {
+                LocalDate start = product.getDiscountStartDate();
+                LocalDate end = product.getDiscountEndDate();
+                if (start != null && end != null && !today.isBefore(start) && !today.isAfter(end)) {
+                    yield product.getDiscountRate();
+                }
+                yield 0;
+            }
+            default -> 0;
+        };
     }
 
     private String generateOrderNumber() {

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
@@ -2,16 +2,24 @@ package com.daebbang.daebbangcore.domain.order.service.impl;
 
 import com.daebbang.daebbangcommon.error.BusinessException;
 import com.daebbang.daebbangcommon.error.UserErrorCode;
+import com.daebbang.daebbangcore.domain.order.command.OrderCancelCommand;
 import com.daebbang.daebbangcore.domain.order.command.OrderConfirmCommand;
 import com.daebbang.daebbangcore.domain.order.command.OrderItemCommand;
+import com.daebbang.daebbangcore.domain.order.command.OrderPartialCancelCommand;
 import com.daebbang.daebbangcore.domain.order.command.OrderPrepareCommand;
+import com.daebbang.daebbangcore.domain.order.dto.OrderFullDetailResult;
 import com.daebbang.daebbangcore.domain.order.dto.OrderPrepareResponse;
+import com.daebbang.daebbangcore.domain.order.dto.OrderStatusCountResult;
+import com.daebbang.daebbangcore.domain.order.dto.OrderSummaryResult;
+import com.daebbang.daebbangcore.domain.order.entity.OrderDetailStatus;
 import com.daebbang.daebbangcore.domain.order.entity.OrderDetails;
+import com.daebbang.daebbangcore.domain.order.entity.OrderStatus;
 import com.daebbang.daebbangcore.domain.order.entity.Orders;
 import com.daebbang.daebbangcore.domain.order.entity.Payment;
+import com.daebbang.daebbangcore.domain.order.event.StockInvalidateEvent;
 import com.daebbang.daebbangcore.domain.order.repository.OrdersRepository;
-import com.daebbang.daebbangcore.domain.order.repository.PaymentRepository;
 import com.daebbang.daebbangcore.domain.order.service.OrderService;
+import com.daebbang.daebbangcore.domain.order.service.PaymentService;
 import com.daebbang.daebbangcore.domain.order.service.StockCacheService;
 import com.daebbang.daebbangcore.domain.order.session.OrderSession;
 import com.daebbang.daebbangcore.domain.order.session.OrderSessionItem;
@@ -33,10 +41,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import lombok.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,12 +64,13 @@ public class OrderServiceImpl implements OrderService {
     private final UserService userService;
     private final ProductDetailsService productDetailsService;
     private final OrdersRepository ordersRepository;
-    private final PaymentRepository paymentRepository;
+    private final PaymentService paymentService;
     private final StockCacheService stockCacheService;
     private final OrderSessionRedisRepository orderSessionRedisRepository;
     private final TossPaymentClient tossPaymentClient;
     private final RedissonClient redissonClient;
     private final OrderStockReserveRedisRepository stockReserveRedisRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public OrderPrepareResponse prepare(OrderPrepareCommand command) {
@@ -77,7 +90,6 @@ public class OrderServiceImpl implements OrderService {
                     }
 
                     stockCacheService.decreaseStock(item.productDetailId(), item.quantity());
-                    // merge로 동일 productDetailId 중복 요청 처리
                     decreasedStocks.merge(item.productDetailId(), item.quantity(), Integer::sum);
 
                     ProductDetails pd = productDetailsService.getProductDetailsById(item.productDetailId());
@@ -228,7 +240,7 @@ public class OrderServiceImpl implements OrderService {
                     approvedAt
                 );
                 payment.update();
-                paymentRepository.save(payment);
+                paymentService.save(payment);
 
                 log.info("[Order] confirm 완료 - orderNumber: {}, method: {}",
                     command.orderNumber(), tossResponse.getMethod());
@@ -260,9 +272,210 @@ public class OrderServiceImpl implements OrderService {
         session.getItems().forEach(i -> stockCacheService.invalidateStock(i.getProductDetailId()));
     }
 
+    @Override
+    @Transactional
+    public void cancel(OrderCancelCommand command) {
+        // 1. 주문 조회 (userId 포함 → 타인 주문 취소 방지)
+        Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(command.orderNumber(), command.userId())
+            .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
+
+        // 2. 취소 가능 상태 검증 (배송중 이후는 취소 불가 → 반품 프로세스 이용)
+        if (order.getOrderStatus() != OrderStatus.PAID
+            && order.getOrderStatus() != OrderStatus.WAITING_DEPOSIT
+            && order.getOrderStatus() != OrderStatus.PREPARING_DELIVERY) {
+            throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+        }
+
+        // 3. 결제 조회
+        Payment payment = paymentService.findByOrder(order);
+
+        // 4. Toss 전액 취소 — 실패 시 예외 throw → 트랜잭션 롤백 (DB 변경 없음)
+        tossPaymentClient.cancel(payment.getPaymentKey(), command.cancelReason());
+
+        // 5. NORMAL 상태인 OrderDetails 모두 취소
+        for (OrderDetails detail : order.getOrderList()) {
+            if (detail.getStatus() == OrderDetailStatus.NORMAL) {
+                detail.cancelRequest();
+                detail.cancel();
+            }
+        }
+
+        // 6. Orders 상태 취소로 변경
+        order.cancel();
+
+        // 7. 결제 취소 이력 기록 (전액: 남은 미취소 금액 전부)
+        int remainingAmount = payment.getTotalAmount() - payment.getTotalCancelAmount();
+        paymentService.recordCancel(payment, command.cancelReason(), remainingAmount);
+
+        // 8. DB 재고 복원
+        for (OrderDetails detail : order.getOrderList()) {
+            productDetailsService.increaseStock(
+                detail.getProductDetail().getId(), detail.getQuantity()
+            );
+        }
+
+        // 9. 이벤트 발행 → 트랜잭션 커밋 후 Redis 캐시 무효화
+        //    롤백 시에는 AFTER_COMMIT 리스너가 실행되지 않으므로 Redis/DB 정합성 보장
+        List<Long> productDetailIds = order.getOrderList().stream()
+            .map(d -> d.getProductDetail().getId())
+            .toList();
+        eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+
+        log.info("[Order] 전체 취소 완료 - orderNumber: {}, userId: {}",
+            command.orderNumber(), command.userId());
+    }
+
+    @Override
+    @Transactional
+    public void cancelPartial(OrderPartialCancelCommand command) {
+        // 1. 주문 조회 (userId 포함 → 타인 주문 취소 방지)
+        Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(command.orderNumber(), command.userId())
+            .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
+
+        // 2. 일부 취소는 PAID 상태만 허용 (WAITING_DEPOSIT은 전액 취소만)
+        if (order.getOrderStatus() != OrderStatus.PAID) {
+            throw new BusinessException(UserErrorCode.ORDER_CANCEL_NOT_ALLOWED);
+        }
+
+        // 3. 취소 대상 detail 검증
+        List<Long> targetIds = command.orderDetailIds();
+        if (targetIds == null || targetIds.isEmpty()) {
+            throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
+        }
+
+        List<OrderDetails> targetDetails = order.getOrderList().stream()
+            .filter(d -> targetIds.contains(d.getId()))
+            .toList();
+
+        // 요청한 ID 수와 실제 조회 수가 다르면 → 해당 주문에 없는 ID가 포함됨
+        if (targetDetails.size() != targetIds.size()) {
+            throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
+        }
+
+        // 이미 취소된 항목이 포함된 경우 거부
+        boolean hasAlreadyCancelled = targetDetails.stream()
+            .anyMatch(d -> d.getStatus() != OrderDetailStatus.NORMAL);
+        if (hasAlreadyCancelled) {
+            throw new BusinessException(UserErrorCode.ORDER_PARTIAL_CANCEL_INVALID);
+        }
+
+        // 4. 취소 금액 계산 (선택된 detail의 discountPrice 합계)
+        int cancelAmount = targetDetails.stream()
+            .mapToInt(OrderDetails::getDiscountPrice)
+            .sum();
+
+        // 5. 결제 조회
+        Payment payment = paymentService.findByOrder(order);
+
+        // 6. Toss 부분 취소 — 실패 시 예외 throw → 트랜잭션 롤백 (DB 변경 없음)
+        tossPaymentClient.cancel(payment.getPaymentKey(), command.cancelReason(), cancelAmount);
+
+        // 7. 선택된 detail 취소 처리
+        for (OrderDetails detail : targetDetails) {
+            detail.cancelRequest();
+            detail.cancel();
+        }
+
+        // 8. 모든 detail이 취소됐으면 Orders도 CANCELLED
+        boolean allCancelled = order.getOrderList().stream()
+            .allMatch(d -> d.getStatus() == OrderDetailStatus.CANCELLED);
+        if (allCancelled) {
+            order.cancel();
+        }
+
+        // 9. 결제 취소 이력 기록 (부분 취소)
+        paymentService.recordCancel(payment, command.cancelReason(), cancelAmount);
+
+        // 10. 취소된 detail들의 DB 재고 복원
+        for (OrderDetails detail : targetDetails) {
+            productDetailsService.increaseStock(
+                detail.getProductDetail().getId(), detail.getQuantity()
+            );
+        }
+
+        // 11. 이벤트 발행 → 트랜잭션 커밋 후 Redis 캐시 무효화 (취소된 상품만)
+        List<Long> productDetailIds = targetDetails.stream()
+            .map(d -> d.getProductDetail().getId())
+            .toList();
+        eventPublisher.publishEvent(new StockInvalidateEvent(productDetailIds));
+
+        log.info("[Order] 일부 취소 완료 - orderNumber: {}, userId: {}, 취소금액: {}",
+            command.orderNumber(), command.userId(), cancelAmount);
+    }
+
+    @Override
+    public Page<@NonNull OrderSummaryResult> getOrderList(Long userId, LocalDateTime start,
+                                                  LocalDateTime end, Pageable pageable) {
+        return ordersRepository.findOrdersByUserIdAndDateRange(userId, start, end, pageable)
+            .map(this::toSummaryResult);
+    }
+
+    @Override
+    public OrderFullDetailResult getOrderDetail(Long userId, String orderNumber) {
+        Orders order = ordersRepository.findOrderDetailByOrderNumberAndUserId(orderNumber, userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.ORDER_NOT_FOUND));
+        return toFullDetailResult(order);
+    }
+
+    @Override
+    public OrderStatusCountResult getOrderStatusCount(Long userId, LocalDateTime start,
+                                                       LocalDateTime end) {
+        return ordersRepository.countOrderStatusByUserIdAndDateRange(userId, start, end);
+    }
+
+    private OrderSummaryResult toSummaryResult(Orders order) {
+        List<OrderDetails> details = order.getOrderList();
+        OrderDetails first = details.isEmpty() ? null : details.get(0);
+        int totalQuantity = details.stream().mapToInt(OrderDetails::getQuantity).sum();
+
+        return new OrderSummaryResult(
+            order.getId(),
+            order.getOrderNumber(),
+            order.getOrderStatus(),
+            order.getCreatedAt(),
+            order.getPaymentAmount(),
+            totalQuantity,
+            first != null ? first.getProductDetail().getProduct().getProductName() : null,
+            first != null ? first.getProductDetail().getProduct().getMainImageUrl() : null,
+            first != null ? first.getProductDetail().getColor() : null,
+            first != null ? first.getProductDetail().getSize() : null
+        );
+    }
+
+    private OrderFullDetailResult toFullDetailResult(Orders order) {
+        List<OrderFullDetailResult.OrderDetailItem> items = order.getOrderList().stream()
+            .map(d -> new OrderFullDetailResult.OrderDetailItem(
+                d.getId(),
+                d.getProductDetail().getId(),
+                d.getProductDetail().getProduct().getProductName(),
+                d.getProductDetail().getProduct().getMainImageUrl(),
+                d.getProductDetail().getColor(),
+                d.getProductDetail().getColorCode(),
+                d.getProductDetail().getSize(),
+                d.getQuantity(),
+                d.getOriginalPrice(),
+                d.getDiscountRate(),
+                d.getDiscountPrice(),
+                d.getStatus()
+            ))
+            .toList();
+
+        return new OrderFullDetailResult(
+            order.getOrderNumber(),
+            order.getOrderStatus(),
+            order.getCreatedAt(),
+            order.getTotalOriginalAmount(),
+            order.getTotalSellingAmount(),
+            order.getShippingFee(),
+            order.getUsedPoint(),
+            order.getPaymentAmount(),
+            items
+        );
+    }
+
     private String generateOrderNumber() {
         String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
         String random = UUID.randomUUID().toString().replace("-", "").substring(0, 10).toUpperCase();
-        return date + "-" + random; // 8 + 1 + 10 = 19자
+        return date + "-" + random;
     }
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/PaymentServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/PaymentServiceImpl.java
@@ -1,0 +1,44 @@
+package com.daebbang.daebbangcore.domain.order.service.impl;
+
+import com.daebbang.daebbangcommon.error.BusinessException;
+import com.daebbang.daebbangcommon.error.UserErrorCode;
+import com.daebbang.daebbangcore.domain.order.entity.Orders;
+import com.daebbang.daebbangcore.domain.order.entity.Payment;
+import com.daebbang.daebbangcore.domain.order.entity.PaymentCancels;
+import com.daebbang.daebbangcore.domain.order.repository.PaymentRepository;
+import com.daebbang.daebbangcore.domain.order.service.PaymentService;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentServiceImpl implements PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    @Override
+    @Transactional
+    public void save(Payment payment) {
+        paymentRepository.save(payment);
+    }
+
+    @Override
+    public Payment findByOrder(Orders order) {
+        return paymentRepository.findByOrder(order)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.PAYMENT_NOT_FOUND));
+    }
+
+    /**
+     * 트랜잭션 내에서 호출되므로 별도 save 불필요.
+     * Payment는 이미 영속 상태 → addCancel() 후 dirty checking으로 자동 반영.
+     */
+    @Override
+    @Transactional
+    public void recordCancel(Payment payment, String cancelReason, int cancelAmount) {
+        PaymentCancels cancel = PaymentCancels.create(cancelReason, cancelAmount, LocalDateTime.now());
+        payment.addCancel(cancel);
+    }
+}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/product/repository/ProductDetailsRepository.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/product/repository/ProductDetailsRepository.java
@@ -14,4 +14,8 @@ public interface ProductDetailsRepository extends JpaRepository<@NonNull Product
     @Modifying(clearAutomatically = true)
     @Query("UPDATE ProductDetails pd SET pd.stock = pd.stock - :quantity WHERE pd.id = :id AND pd.stock >= :quantity AND :quantity > 0")
     int decreaseStock(@Param("id") Long id, @Param("quantity") int quantity);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE ProductDetails pd SET pd.stock = pd.stock + :quantity WHERE pd.id = :id AND :quantity > 0")
+    int increaseStock(@Param("id") Long id, @Param("quantity") int quantity);
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/product/service/ProductDetailsService.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/product/service/ProductDetailsService.java
@@ -7,4 +7,6 @@ public interface ProductDetailsService {
     ProductDetails getProductDetailsById(Long id);
 
     int decreaseStock(Long id, int quantity);
+
+    int increaseStock(Long id, int quantity);
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/product/service/impl/ProductDetailsServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/product/service/impl/ProductDetailsServiceImpl.java
@@ -27,4 +27,10 @@ public class ProductDetailsServiceImpl implements ProductDetailsService {
     public int decreaseStock(Long id, int quantity) {
         return productDetailsRepository.decreaseStock(id, quantity);
     }
+
+    @Override
+    @Transactional
+    public int increaseStock(Long id, int quantity) {
+        return productDetailsRepository.increaseStock(id, quantity);
+    }
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/user/entity/Users.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/user/entity/Users.java
@@ -11,7 +11,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/user/service/impl/UserServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/user/service/impl/UserServiceImpl.java
@@ -17,13 +17,11 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@EnableAsync
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserServiceImpl implements UserService {

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/infra/config/AsyncConfig.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/infra/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.daebbang.daebbangcore.infra.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "stockCacheExecutor")
+    public Executor stockCacheExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("stock-cache-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(10);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/infra/toss/TossPaymentClient.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/infra/toss/TossPaymentClient.java
@@ -13,6 +13,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,9 +70,20 @@ public class TossPaymentClient {
         }
     }
 
+
     public void cancel(String paymentKey, String cancelReason) {
+        cancel(paymentKey, cancelReason, null);
+    }
+
+
+    public void cancel(String paymentKey, String cancelReason, Integer cancelAmount) {
         try {
-            String body = objectMapper.writeValueAsString(Map.of("cancelReason", cancelReason));
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("cancelReason", cancelReason);
+            if (cancelAmount != null) {
+                payload.put("cancelAmount", cancelAmount);
+            }
+            String body = objectMapper.writeValueAsString(payload);
 
             HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(BASE_URL + "/v1/payments/" + paymentKey + "/cancel"))
@@ -86,17 +98,17 @@ public class TossPaymentClient {
             if (response.statusCode() != 200) {
                 log.error("[Toss] 결제 취소 실패 - paymentKey: {}, status: {}",
                     paymentKey, response.statusCode());
-                throw new BusinessException(UserErrorCode.PAYMENT_CONFIRMATION_FAILED);
+                throw new BusinessException(UserErrorCode.PAYMENT_CANCEL_FAILED);
             }
 
         } catch (BusinessException e) {
             throw e;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new BusinessException(UserErrorCode.PAYMENT_CONFIRMATION_FAILED);
+            throw new BusinessException(UserErrorCode.PAYMENT_CANCEL_FAILED);
         } catch (Exception e) {
             log.error("[Toss] 결제 취소 중 예외 - paymentKey: {}, error: {}", paymentKey, e.getMessage(), e);
-            throw new BusinessException(UserErrorCode.PAYMENT_CONFIRMATION_FAILED);
+            throw new BusinessException(UserErrorCode.PAYMENT_CANCEL_FAILED);
         }
     }
 

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/infra/toss/TossPaymentClient.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/infra/toss/TossPaymentClient.java
@@ -71,12 +71,12 @@ public class TossPaymentClient {
     }
 
 
-    public void cancel(String paymentKey, String cancelReason) {
-        cancel(paymentKey, cancelReason, null);
+    public void cancel(String paymentKey, String cancelReason, String idempotencyKey) {
+        cancel(paymentKey, cancelReason, null, idempotencyKey);
     }
 
 
-    public void cancel(String paymentKey, String cancelReason, Integer cancelAmount) {
+    public void cancel(String paymentKey, String cancelReason, Integer cancelAmount, String idempotencyKey) {
         try {
             Map<String, Object> payload = new HashMap<>();
             payload.put("cancelReason", cancelReason);
@@ -89,6 +89,7 @@ public class TossPaymentClient {
                 .uri(URI.create(BASE_URL + "/v1/payments/" + paymentKey + "/cancel"))
                 .header("Authorization", basicAuth())
                 .header("Content-Type", "application/json")
+                .header("Idempotency-Key", idempotencyKey)
                 .timeout(Duration.ofSeconds(30))
                 .POST(BodyPublishers.ofString(body))
                 .build();


### PR DESCRIPTION
## 💻 작업 내용
<!-- 작업한 내용을 작성해주세요. -->
1. 전체 취소
2. 부분 취소
3. 주문 목록 조회
4. 주문 목록 상세 조회
5. 배송 상태 갯수 조회
<br></br>
## 💬 추가 전달 사항
<!-- 추가로 전달할 내용이 있다면 적어주세요. -->

<br></br>
## 💁‍♂️ 관련 Issues
<!-- 관련된 이슈 번호를 작성해 주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 주문 목록(기간 조회·기본 페이징/정렬), 주문 상세, 배송 현황 건수 조회 추가
  * 주문 전체 취소 및 부분 취소 기능 추가(취소 사유/대상 항목 검증, 취소 금액 지정·중복 방지)
  * 재고 증감 지원 및 재고 무효화 이벤트 발행, 비동기 재고 캐시 무효화 처리 도입
  * 결제 취소에 금액·아이덴포텐시티 지원 및 취소 기록화

* **Documentation**
  * OpenAPI/Swagger에 주문 관련 엔드포인트·스키마·예시 추가/확장

* **Tests**
  * 주문 조회·취소 관련 컨트롤러 테스트 및 API 문서화(RestDocs) 추가

* **Chores**
  * 응답/에러/성공 코드 확장 및 관련 인터페이스/서비스 정비
<!-- end of auto-generated comment: release notes by coderabbit.ai -->