### PR TITLE
fix: wish check api 응답값 수정

### DIFF
--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/wish/controller/WishListController.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/wish/controller/WishListController.java
@@ -1,6 +1,7 @@
 package com.daebbang.daebbangapi.domain.wish.controller;
 
 import com.daebbang.daebbangapi.domain.wish.dto.request.WishListSaveRequest;
+import com.daebbang.daebbangapi.domain.wish.dto.response.WishCheckInfo;
 import com.daebbang.daebbangapi.domain.wish.dto.response.WishIdInfo;
 import com.daebbang.daebbangapi.domain.wish.dto.response.WishListInfo;
 import com.daebbang.daebbangcommon.dto.response.CommonResponse;
@@ -47,11 +48,12 @@ public class WishListController {
     }
 
     @GetMapping("/check")
-    public CommonResponse<Boolean> checkWishList(
+    public CommonResponse<WishCheckInfo> checkWishList(
         @AuthenticationPrincipal Long userId,
         @RequestParam @Positive(message = "상품 ID는 1 이상이어야 합니다.") Long productId
     ) {
-        return CommonResponse.success(UserSuccessCode.CHECK_WISH_LIST, wishListService.isWished(userId, productId));
+        var result = wishListService.isWished(userId, productId);
+        return CommonResponse.success(UserSuccessCode.CHECK_WISH_LIST, new WishCheckInfo(result.isPresent(), result.orElse(null)));
     }
 
     @PostMapping

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/wish/dto/response/WishCheckInfo.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/wish/dto/response/WishCheckInfo.java
@@ -1,0 +1,7 @@
+package com.daebbang.daebbangapi.domain.wish.dto.response;
+
+public record WishCheckInfo(
+    boolean isWished,
+    Long wishId
+) {
+}

--- a/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -416,7 +416,7 @@ paths:
               $ref: '#/components/schemas/v1-users486549215'
             examples:
               user/withdraw-user:
-                value: _csrf=q34tOYii711px1Pos-Tk2lK5B7VWLtkKoXlH1DjrtIUOfsjTk0YVWL3G1zlE9mSL0snQvGCBKtc3Tbonlk5x7VyP0L1sGPDn
+                value: _csrf=LQUIV-Fxhbjmplz9WbBaxHo5hgY7Eoh1HKQ4qxRd4-PRmz3JGjxtYNJI54DLwmnJaJ1uphxbqz9YcLBYfZ0PmSNlhoHk-Q38
       responses:
         "200":
           description: "200"
@@ -1268,8 +1268,8 @@ paths:
       tags:
       - WishList
       summary: 위시리스트 여부 조회
-      description: "상품 상세 페이지 진입 후 CSR로 위시리스트 등록 여부를 조회합니다. 등록된 경우 true, 아니면 false를\
-        \ 반환합니다."
+      description: 상품 상세 페이지 진입 후 CSR로 위시리스트 등록 여부를 조회합니다. 등록된 경우 isWished=true와 wishId를
+        반환합니다.
       operationId: wish-lists/check-0
       parameters:
       - name: productId
@@ -1288,10 +1288,10 @@ paths:
               examples:
                 wish-lists/check-01-wished:
                   value: "{\"success\":true,\"status\":200,\"message\":\"위시리스트 여부\
-                    \ 조회에 성공하였습니다.\",\"data\":true}"
+                    \ 조회에 성공하였습니다.\",\"data\":{\"isWished\":true,\"wishId\":1}}"
                 wish-lists/check-02-not-wished:
                   value: "{\"success\":true,\"status\":200,\"message\":\"위시리스트 여부\
-                    \ 조회에 성공하였습니다.\",\"data\":false}"
+                    \ 조회에 성공하였습니다.\",\"data\":{\"isWished\":false,\"wishId\":null}}"
   /v1/orders/{orderNumber}/cancel:
     post:
       tags:
@@ -2359,6 +2359,28 @@ components:
         quantity:
           type: number
           description: 변경할 수량
+    WishListCheckResponse:
+      title: WishListCheckResponse
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            isWished:
+              type: boolean
+              description: 위시리스트 등록 여부
+            wishId:
+              type: number
+              description: 위시리스트 ID (미등록 시 null)
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 응답 메시지
+        status:
+          type: number
+          description: HTTP 상태 코드
     WishListPageResponse:
       title: WishListPageResponse
       type: object
@@ -2774,22 +2796,6 @@ components:
               type: string
               description: 발송된 인증번호 (6자리)
           description: 발송 결과
-        success:
-          type: boolean
-          description: 성공 여부
-        message:
-          type: string
-          description: 응답 메시지
-        status:
-          type: number
-          description: HTTP 상태 코드
-    WishListCheckResponse:
-      title: WishListCheckResponse
-      type: object
-      properties:
-        data:
-          type: boolean
-          description: 위시리스트 등록 여부
         success:
           type: boolean
           description: 성공 여부

--- a/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/wish/controller/WishListControllerTest.java
+++ b/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/wish/controller/WishListControllerTest.java
@@ -23,6 +23,7 @@ import com.daebbang.daebbangapi.config.TestSecurityConfig;
 import com.daebbang.daebbangapi.domain.oauth.service.oauth2.Oauth2UserDetailsService;
 import com.daebbang.daebbangapi.domain.users.service.CustomUserDetailsService;
 import com.daebbang.daebbangapi.domain.wish.dto.request.WishListSaveRequest;
+import java.util.Optional;
 import com.daebbang.daebbangcommon.error.BusinessException;
 import com.daebbang.daebbangcommon.error.UserErrorCode;
 import com.daebbang.daebbangcore.domain.product.entity.DiscountType;
@@ -237,9 +238,9 @@ class WishListControllerTest {
     // ======================== GET /v1/wish-lists/check ========================
 
     @Test
-    @DisplayName("GET /v1/wish-lists/check - 위시리스트 등록 상품이면 true 반환")
+    @DisplayName("GET /v1/wish-lists/check - 위시리스트 등록 상품이면 isWished=true, wishId 반환")
     void checkWishList_wished() throws Exception {
-        given(wishListService.isWished(anyLong(), anyLong())).willReturn(true);
+        given(wishListService.isWished(anyLong(), anyLong())).willReturn(Optional.of(1L));
 
         mockMvc.perform(get(BASE_URL + "/check")
                 .with(authentication(authToken()))
@@ -250,12 +251,13 @@ class WishListControllerTest {
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.status").value(200))
             .andExpect(jsonPath("$.message").value("위시리스트 여부 조회에 성공하였습니다."))
-            .andExpect(jsonPath("$.data").value(true))
+            .andExpect(jsonPath("$.data.isWished").value(true))
+            .andExpect(jsonPath("$.data.wishId").value(1))
             .andDo(document("wish-lists/check-01-wished",
                 resource(ResourceSnippetParameters.builder()
                     .tag("WishList")
                     .summary("위시리스트 여부 조회")
-                    .description("상품 상세 페이지 진입 후 CSR로 위시리스트 등록 여부를 조회합니다. 등록된 경우 true, 아니면 false를 반환합니다.")
+                    .description("상품 상세 페이지 진입 후 CSR로 위시리스트 등록 여부를 조회합니다. 등록된 경우 isWished=true와 wishId를 반환합니다.")
                     .responseSchema(Schema.schema("WishListCheckResponse"))
                     .queryParameters(
                         parameterWithName("productId").description("조회할 상품 ID")
@@ -264,16 +266,17 @@ class WishListControllerTest {
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
                         fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
-                        fieldWithPath("data").type(JsonFieldType.BOOLEAN).description("위시리스트 등록 여부")
+                        fieldWithPath("data.isWished").type(JsonFieldType.BOOLEAN).description("위시리스트 등록 여부"),
+                        fieldWithPath("data.wishId").type(JsonFieldType.NUMBER).description("위시리스트 ID (미등록 시 null)")
                     )
                     .build()
                 )));
     }
 
     @Test
-    @DisplayName("GET /v1/wish-lists/check - 미등록 상품이면 false 반환")
+    @DisplayName("GET /v1/wish-lists/check - 미등록 상품이면 isWished=false, wishId=null 반환")
     void checkWishList_notWished() throws Exception {
-        given(wishListService.isWished(anyLong(), anyLong())).willReturn(false);
+        given(wishListService.isWished(anyLong(), anyLong())).willReturn(Optional.empty());
 
         mockMvc.perform(get(BASE_URL + "/check")
                 .with(authentication(authToken()))
@@ -281,12 +284,13 @@ class WishListControllerTest {
                 .accept(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data").value(false))
+            .andExpect(jsonPath("$.data.isWished").value(false))
+            .andExpect(jsonPath("$.data.wishId").isEmpty())
             .andDo(document("wish-lists/check-02-not-wished",
                 resource(ResourceSnippetParameters.builder()
                     .tag("WishList")
                     .summary("위시리스트 여부 조회 - 미등록")
-                    .description("위시리스트에 등록되지 않은 상품은 false를 반환합니다.")
+                    .description("위시리스트에 등록되지 않은 상품은 isWished=false, wishId=null을 반환합니다.")
                     .responseSchema(Schema.schema("WishListCheckResponse"))
                     .queryParameters(
                         parameterWithName("productId").description("조회할 상품 ID")
@@ -295,7 +299,8 @@ class WishListControllerTest {
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
                         fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
-                        fieldWithPath("data").type(JsonFieldType.BOOLEAN).description("위시리스트 등록 여부")
+                        fieldWithPath("data.isWished").type(JsonFieldType.BOOLEAN).description("위시리스트 등록 여부"),
+                        fieldWithPath("data.wishId").type(JsonFieldType.NUMBER).optional().description("위시리스트 ID (미등록 시 null)")
                     )
                     .build()
                 )));

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/wish/service/WishListService.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/wish/service/WishListService.java
@@ -2,6 +2,7 @@ package com.daebbang.daebbangcore.domain.wish.service;
 
 import com.daebbang.daebbangcore.domain.wish.dto.WishListQueryResult;
 import java.util.List;
+import java.util.Optional;
 import lombok.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,7 +11,7 @@ public interface WishListService {
 
     Page<@NonNull WishListQueryResult> getWishList(Long userId, Pageable pageable);
 
-    boolean isWished(Long userId, Long productId);
+    Optional<Long> isWished(Long userId, Long productId);
 
     Long addWishList(Long userId, Long productId);
 

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/wish/service/impl/WishListServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/wish/service/impl/WishListServiceImpl.java
@@ -11,6 +11,7 @@ import com.daebbang.daebbangcore.domain.wish.entity.WishList;
 import com.daebbang.daebbangcore.domain.wish.repository.WishListRepository;
 import com.daebbang.daebbangcore.domain.wish.service.WishListService;
 import java.util.List;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -33,8 +34,8 @@ public class WishListServiceImpl implements WishListService {
     }
 
     @Override
-    public boolean isWished(Long userId, Long productId) {
-        return wishListRepository.findWishListByUserIdAndProductId(userId, productId).isPresent();
+    public Optional<Long> isWished(Long userId, Long productId) {
+        return wishListRepository.findWishListByUserIdAndProductId(userId, productId).map(WishList::getId);
     }
 
     @Override


### PR DESCRIPTION
## 💻 작업 내용
<!-- 작업한 내용을 작성해주세요. -->

<br></br>
## 💬 추가 전달 사항
<!-- 추가로 전달할 내용이 있다면 적어주세요. -->

<br></br>
## 💁‍♂️ 관련 Issues
<!-- 관련된 이슈 번호를 작성해 주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 위시 확인 API가 위시 여부 확인 시 위시 항목의 고유 ID를 함께 제공합니다. 클라이언트는 위시 상태 여부와 해당 위시 ID를 동시에 획득하여 더욱 정확한 데이터 처리가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->