### PR TITLE
feat:order api 정보 추가

### DIFF
--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderPrepareRequest.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderPrepareRequest.java
@@ -6,19 +6,26 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record OrderPrepareRequest(
     @NotEmpty(message = "주문 상품 목록은 필수입니다.") List<@Valid OrderItemRequest> items,
     @Min(value = 0, message = "포인트는 0 이상이어야 합니다.") int usedPoint,
-    @NotBlank(message = "수령인은 필수입니다.") String receiver,
-    @NotBlank(message = "수령인 연락처는 필수입니다.") String receiverPhoneNumber,
-    @NotBlank(message = "우편번호는 필수입니다.") String zipCode,
-    @NotBlank(message = "주소는 필수입니다.") String address,
-    @NotBlank(message = "상세주소는 필수입니다.") String detailAddress,
+    @NotBlank(message = "수령인은 필수입니다.")
+    @Size(max = 50, message = "수령인 이름은 50자 이내여야 합니다.") String receiver,
+    @NotBlank(message = "수령인 연락처는 필수입니다.")
+    @Pattern(regexp = "^01[0-9]{8,9}$", message = "유효하지 않은 전화번호 형식입니다.") String receiverPhoneNumber,
+    @NotBlank(message = "우편번호는 필수입니다.")
+    @Pattern(regexp = "^\\d{5}$", message = "우편번호는 5자리 숫자여야 합니다.") String zipCode,
+    @NotBlank(message = "주소는 필수입니다.")
+    @Size(max = 200, message = "주소는 200자 이내여야 합니다.") String address,
+    @NotBlank(message = "상세주소는 필수입니다.")
+    @Size(max = 100, message = "상세주소는 100자 이내여야 합니다.") String detailAddress,
     @Min(value = 0, message = "배송비는 0 이상이어야 합니다.") int shippingFee,
     boolean isAddToAddressBook,
-    @Nullable String addressAlias
+    @Nullable @Size(max = 50, message = "주소록 별칭은 50자 이내여야 합니다.") String addressAlias
 ) {
     public OrderPrepareCommand toCommand(Long userId) {
         return new OrderPrepareCommand(

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderPrepareRequest.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderPrepareRequest.java
@@ -1,20 +1,38 @@
 package com.daebbang.daebbangapi.domain.order.dto.request;
 
 import com.daebbang.daebbangcore.domain.order.command.OrderPrepareCommand;
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
 public record OrderPrepareRequest(
     @NotEmpty(message = "주문 상품 목록은 필수입니다.") List<@Valid OrderItemRequest> items,
-    @Min(value = 0, message = "포인트는 0 이상이어야 합니다.") int usedPoint
+    @Min(value = 0, message = "포인트는 0 이상이어야 합니다.") int usedPoint,
+    @NotBlank(message = "수령인은 필수입니다.") String receiver,
+    @NotBlank(message = "수령인 연락처는 필수입니다.") String receiverPhoneNumber,
+    @NotBlank(message = "우편번호는 필수입니다.") String zipCode,
+    @NotBlank(message = "주소는 필수입니다.") String address,
+    @NotBlank(message = "상세주소는 필수입니다.") String detailAddress,
+    @Min(value = 0, message = "배송비는 0 이상이어야 합니다.") int shippingFee,
+    boolean isAddToAddressBook,
+    @Nullable String addressAlias
 ) {
     public OrderPrepareCommand toCommand(Long userId) {
         return new OrderPrepareCommand(
             userId,
             items.stream().map(OrderItemRequest::toCommand).toList(),
-            usedPoint
+            usedPoint,
+            receiver,
+            receiverPhoneNumber,
+            zipCode,
+            address,
+            detailAddress,
+            shippingFee,
+            isAddToAddressBook,
+            addressAlias
         );
     }
 }

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderPrepareRequest.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/request/OrderPrepareRequest.java
@@ -24,7 +24,9 @@ public record OrderPrepareRequest(
     @NotBlank(message = "상세주소는 필수입니다.")
     @Size(max = 100, message = "상세주소는 100자 이내여야 합니다.") String detailAddress,
     @Min(value = 0, message = "배송비는 0 이상이어야 합니다.") int shippingFee,
+    @Nullable @Size(max = 100, message = "배송 요청사항은 100자 이내여야 합니다.") String orderNote,
     boolean isAddToAddressBook,
+    boolean isDefaultAddress,
     @Nullable @Size(max = 50, message = "주소록 별칭은 50자 이내여야 합니다.") String addressAlias
 ) {
     public OrderPrepareCommand toCommand(Long userId) {
@@ -38,7 +40,9 @@ public record OrderPrepareRequest(
             address,
             detailAddress,
             shippingFee,
+            orderNote,
             isAddToAddressBook,
+            isDefaultAddress,
             addressAlias
         );
     }

--- a/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/response/OrderListItemResponse.java
+++ b/daebbang-api/src/main/java/com/daebbang/daebbangapi/domain/order/dto/response/OrderListItemResponse.java
@@ -13,7 +13,9 @@ public record OrderListItemResponse(
     String representativeProductName,
     String representativeImageUrl,
     String representativeColor,
-    String representativeSize
+    String representativeSize,
+    int representativeUnitPrice,
+    int representativeQuantity
 ) {
     public static OrderListItemResponse from(OrderSummaryResult result) {
         return new OrderListItemResponse(
@@ -25,7 +27,9 @@ public record OrderListItemResponse(
             result.representativeProductName(),
             result.representativeImageUrl(),
             result.representativeColor(),
-            result.representativeSize()
+            result.representativeSize(),
+            result.representativeUnitPrice(),
+            result.representativeQuantity()
         );
     }
 }

--- a/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -292,7 +292,8 @@ paths:
                     ,\"orderStatus\":\"PAID\",\"orderedAt\":\"2026-04-16T10:00:00\"\
                     ,\"paymentAmount\":33000,\"totalQuantity\":2,\"representativeProductName\"\
                     :\"슬림핏 청바지\",\"representativeImageUrl\":\"https://cdn.daebbang.com/img/slim-jeans.jpg\"\
-                    ,\"representativeColor\":\"골드\",\"representativeSize\":\"M\"}],\"\
+                    ,\"representativeColor\":\"골드\",\"representativeSize\":\"M\",\"\
+                    representativeUnitPrice\":30000,\"representativeQuantity\":1}],\"\
                     empty\":false,\"first\":true,\"last\":true,\"number\":0,\"numberOfElements\"\
                     :1,\"pageable\":{\"offset\":0,\"pageNumber\":0,\"pageSize\":10,\"\
                     paged\":true,\"sort\":{\"empty\":true,\"sorted\":false,\"unsorted\"\
@@ -455,7 +456,7 @@ paths:
               $ref: '#/components/schemas/v1-users486549215'
             examples:
               user/withdraw-user:
-                value: _csrf=Bt1qMuonrMxT31K1ZsEM8razyGX04rbQh0vM7ns1jjtKfoPIN-sIUdMTlPR-6zCMUuw4lIXS5QTA29P9t3393U0B6w4rTeep
+                value: _csrf=QcZcqA8BoNgn5MnOMr0zetBmOO-dkoYDQDg5t_fyqiEsEtP5dKdvyW1gmeoKgfz3BZAHT7MHFY759-UuI11d0ZbLnBUfIeeb
       responses:
         "200":
           description: "200"
@@ -759,34 +760,61 @@ paths:
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: '#/components/schemas/v1-orders-prepare1866161413'
+              $ref: '#/components/schemas/v1-orders-prepare-789949242'
             examples:
               order/prepare-empty-items:
-                value: "{\"items\":[],\"usedPoint\":0}"
+                value: "{\"items\":[],\"usedPoint\":0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\"\
+                  :\"01012345678\",\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란\
+                  로 1\",\"detailAddress\":\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\"\
+                  :false,\"addressAlias\":null}"
               order/prepare-invalid-quantity:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":0}],\"usedPoint\"\
-                  :0}"
+                  :0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
+                  ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
+                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
+                  addressAlias\":null}"
               order/prepare-lock-failed:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
-                  :0}"
+                  :0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
+                  ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
+                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
+                  addressAlias\":null}"
               order/prepare-negative-point:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
-                  :-1}"
+                  :-1,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
+                  ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
+                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
+                  addressAlias\":null}"
               order/prepare-out-of-stock:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":999}],\"usedPoint\"\
-                  :0}"
+                  :0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
+                  ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
+                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
+                  addressAlias\":null}"
               order/prepare-point-exceeds:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
-                  :99999}"
+                  :99999,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
+                  ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
+                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
+                  addressAlias\":null}"
               order/prepare-success:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
-                  :0}"
+                  :0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
+                  ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
+                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
+                  addressAlias\":null}"
               order/prepare-success-free-shipping:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":2}],\"usedPoint\"\
-                  :0}"
+                  :0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
+                  ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
+                  :\"101동 202호\",\"shippingFee\":0,\"isAddToAddressBook\":false,\"\
+                  addressAlias\":null}"
               order/prepare-success-with-point:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
-                  :3000}"
+                  :3000,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
+                  ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
+                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
+                  addressAlias\":null}"
       responses:
         "400":
           description: "400"
@@ -1661,8 +1689,8 @@ paths:
                 user/check-login-id-blank:
                   value: "{\"success\":false,\"status\":400,\"message\":\"잘못된 입력값입\
                     니다.\",\"data\":null,\"errors\":[{\"field\":\"loginId\",\"message\"\
-                    :\"아이디는 4자에서 16자 사이여야 합니다.\"},{\"field\":\"loginId\",\"message\"\
-                    :\"아이디는 비어있어서는 안됩니다.\"}]}"
+                    :\"아이디는 비어있어서는 안됩니다.\"},{\"field\":\"loginId\",\"message\":\"아\
+                    이디는 4자에서 16자 사이여야 합니다.\"}]}"
                 user/check-login-id-invalid:
                   value: "{\"success\":false,\"status\":400,\"message\":\"잘못된 입력값입\
                     니다.\",\"data\":null,\"errors\":[{\"field\":\"loginId\",\"message\"\
@@ -2057,125 +2085,6 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
-    OrderListResponse:
-      title: OrderListResponse
-      type: object
-      properties:
-        data:
-          type: object
-          properties:
-            number:
-              type: number
-              description: 현재 페이지 번호
-            numberOfElements:
-              type: number
-              description: 현재 페이지 항목 수
-            size:
-              type: number
-              description: 페이지 크기
-            last:
-              type: boolean
-              description: 마지막 페이지 여부
-            totalPages:
-              type: number
-              description: 전체 페이지 수
-            pageable:
-              type: object
-              properties:
-                paged:
-                  type: boolean
-                  description: 페이징 적용 여부
-                pageNumber:
-                  type: number
-                  description: 현재 페이지 번호
-                offset:
-                  type: number
-                  description: 오프셋
-                pageSize:
-                  type: number
-                  description: 페이지 크기
-                unpaged:
-                  type: boolean
-                  description: 페이징 미적용 여부
-                sort:
-                  type: object
-                  properties:
-                    unsorted:
-                      type: boolean
-                      description: 정렬 미적용 여부
-                    sorted:
-                      type: boolean
-                      description: 정렬 적용 여부
-                    empty:
-                      type: boolean
-                      description: 정렬 조건 없음 여부
-                  description: 정렬 정보
-              description: 페이지 정보
-            sort:
-              type: object
-              properties:
-                unsorted:
-                  type: boolean
-                  description: 정렬 미적용 여부
-                sorted:
-                  type: boolean
-                  description: 정렬 적용 여부
-                empty:
-                  type: boolean
-                  description: 정렬 조건 없음 여부
-              description: 정렬 정보
-            first:
-              type: boolean
-              description: 첫 번째 페이지 여부
-            content:
-              type: array
-              description: 주문 목록 (결과 없음)
-              items:
-                type: object
-                properties:
-                  orderedAt:
-                    type: string
-                    description: 주문 일시
-                  representativeProductName:
-                    type: string
-                    description: 대표 상품명 (첫 번째 상품)
-                  totalQuantity:
-                    type: number
-                    description: 총 상품 수량
-                  orderNumber:
-                    type: string
-                    description: 주문 번호
-                  representativeSize:
-                    type: string
-                    description: 대표 상품 사이즈
-                  orderStatus:
-                    type: string
-                    description: "주문 상태 (PAID, PREPARING_DELIVERY, IN_DELIVERY, DELIVERED,\
-                      \ COMPLETED, CANCELLED 등)"
-                  representativeColor:
-                    type: string
-                    description: 대표 상품 색상
-                  representativeImageUrl:
-                    type: string
-                    description: 대표 상품 이미지 URL
-                  paymentAmount:
-                    type: number
-                    description: 결제 금액
-            empty:
-              type: boolean
-              description: 결과 없음 여부
-            totalElements:
-              type: number
-              description: 전체 주문 수
-        success:
-          type: boolean
-          description: 성공 여부
-        message:
-          type: string
-          description: 응답 메시지
-        status:
-          type: number
-          description: HTTP 상태 코드
     JoinUserRequest:
       title: JoinUserRequest
       type: object
@@ -2530,6 +2439,173 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
+    v1-orders-prepare-789949242:
+      type: object
+      properties:
+        usedPoint:
+          type: number
+          description: 사용 포인트 (결제 금액에서 차감)
+        zipCode:
+          type: string
+          description: 우편번호
+        address:
+          type: string
+          description: 기본 주소
+        shippingFee:
+          type: number
+          description: 배송비
+        receiver:
+          type: string
+          description: 수령인 이름
+        receiverPhoneNumber:
+          type: string
+          description: 수령인 연락처
+        detailAddress:
+          type: string
+          description: 상세 주소
+        addressAlias:
+          type: string
+          description: "주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)"
+        items:
+          type: array
+          description: 주문 상품 목록
+          items:
+            type: object
+            properties:
+              quantity:
+                type: number
+                description: 주문 수량
+              productDetailId:
+                type: number
+                description: 상품 상세 ID
+        isAddToAddressBook:
+          type: boolean
+          description: 주소록 추가 여부
+    OrderListResponse:
+      title: OrderListResponse
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            number:
+              type: number
+              description: 현재 페이지 번호
+            numberOfElements:
+              type: number
+              description: 현재 페이지 항목 수
+            size:
+              type: number
+              description: 페이지 크기
+            last:
+              type: boolean
+              description: 마지막 페이지 여부
+            totalPages:
+              type: number
+              description: 전체 페이지 수
+            pageable:
+              type: object
+              properties:
+                paged:
+                  type: boolean
+                  description: 페이징 적용 여부
+                pageNumber:
+                  type: number
+                  description: 현재 페이지 번호
+                offset:
+                  type: number
+                  description: 오프셋
+                pageSize:
+                  type: number
+                  description: 페이지 크기
+                unpaged:
+                  type: boolean
+                  description: 페이징 미적용 여부
+                sort:
+                  type: object
+                  properties:
+                    unsorted:
+                      type: boolean
+                      description: 정렬 미적용 여부
+                    sorted:
+                      type: boolean
+                      description: 정렬 적용 여부
+                    empty:
+                      type: boolean
+                      description: 정렬 조건 없음 여부
+                  description: 정렬 정보
+              description: 페이지 정보
+            sort:
+              type: object
+              properties:
+                unsorted:
+                  type: boolean
+                  description: 정렬 미적용 여부
+                sorted:
+                  type: boolean
+                  description: 정렬 적용 여부
+                empty:
+                  type: boolean
+                  description: 정렬 조건 없음 여부
+              description: 정렬 정보
+            first:
+              type: boolean
+              description: 첫 번째 페이지 여부
+            content:
+              type: array
+              description: 주문 목록 (결과 없음)
+              items:
+                type: object
+                properties:
+                  orderedAt:
+                    type: string
+                    description: 주문 일시
+                  representativeProductName:
+                    type: string
+                    description: 대표 상품명 (첫 번째 상품)
+                  totalQuantity:
+                    type: number
+                    description: 총 상품 수량
+                  orderNumber:
+                    type: string
+                    description: 주문 번호
+                  representativeSize:
+                    type: string
+                    description: 대표 상품 사이즈
+                  orderStatus:
+                    type: string
+                    description: "주문 상태 (PAID, PREPARING_DELIVERY, IN_DELIVERY, DELIVERED,\
+                      \ COMPLETED, CANCELLED 등)"
+                  representativeQuantity:
+                    type: number
+                    description: 대표 상품 주문 수량
+                  representativeColor:
+                    type: string
+                    description: 대표 상품 색상
+                  representativeImageUrl:
+                    type: string
+                    description: 대표 상품 이미지 URL
+                  representativeUnitPrice:
+                    type: number
+                    description: 대표 상품 단가 (할인 적용 후)
+                  paymentAmount:
+                    type: number
+                    description: 결제 금액
+            empty:
+              type: boolean
+              description: 결과 없음 여부
+            totalElements:
+              type: number
+              description: 전체 주문 수
+        success:
+          type: boolean
+          description: 성공 여부
+        message:
+          type: string
+          description: 응답 메시지
+        status:
+          type: number
+          description: HTTP 상태 코드
     ProductDetailResponse:
       title: ProductDetailResponse
       type: object
@@ -2689,24 +2765,6 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
-    v1-orders-prepare1866161413:
-      type: object
-      properties:
-        usedPoint:
-          type: number
-          description: 사용 포인트 (결제 금액에서 차감)
-        items:
-          type: array
-          description: 주문 상품 목록
-          items:
-            type: object
-            properties:
-              quantity:
-                type: number
-                description: 주문 수량
-              productDetailId:
-                type: number
-                description: 상품 상세 ID
     ProductMainCardListResponse:
       title: ProductMainCardListResponse
       type: object

--- a/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -456,7 +456,7 @@ paths:
               $ref: '#/components/schemas/v1-users486549215'
             examples:
               user/withdraw-user:
-                value: _csrf=cV534udAK2MprtvmT_MjVz3ydCOV9mmB2cUyM39GMPCaR-TORzxG0tMkG1MEluqDed4XZgvCWRvxlV2s7PJWC0lyU5H-fteq
+                value: _csrf=OHSiEXXlmXk_VmyDf-Zx6qbUxC5JFBsJo7HfcEL0lWyruBaDXETDcxHRqBoSNwi3HMtF2sDm6U94LXkkm4C5RCaS8wqc3XXl
       responses:
         "200":
           description: "200"
@@ -760,61 +760,62 @@ paths:
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: '#/components/schemas/v1-orders-prepare-789949242'
+              $ref: '#/components/schemas/v1-orders-prepare-1990526072'
             examples:
               order/prepare-empty-items:
                 value: "{\"items\":[],\"usedPoint\":0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\"\
                   :\"01012345678\",\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란\
-                  로 1\",\"detailAddress\":\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\"\
-                  :false,\"addressAlias\":null}"
+                  로 1\",\"detailAddress\":\"101동 202호\",\"shippingFee\":3000,\"orderNote\"\
+                  :null,\"isAddToAddressBook\":false,\"isDefaultAddress\":false,\"\
+                  addressAlias\":null}"
               order/prepare-invalid-quantity:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":0}],\"usedPoint\"\
                   :0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
                   ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
-                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
-                  addressAlias\":null}"
+                  :\"101동 202호\",\"shippingFee\":3000,\"orderNote\":null,\"isAddToAddressBook\"\
+                  :false,\"isDefaultAddress\":false,\"addressAlias\":null}"
               order/prepare-lock-failed:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
                   :0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
                   ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
-                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
-                  addressAlias\":null}"
+                  :\"101동 202호\",\"shippingFee\":3000,\"orderNote\":null,\"isAddToAddressBook\"\
+                  :false,\"isDefaultAddress\":false,\"addressAlias\":null}"
               order/prepare-negative-point:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
                   :-1,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
                   ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
-                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
-                  addressAlias\":null}"
+                  :\"101동 202호\",\"shippingFee\":3000,\"orderNote\":null,\"isAddToAddressBook\"\
+                  :false,\"isDefaultAddress\":false,\"addressAlias\":null}"
               order/prepare-out-of-stock:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":999}],\"usedPoint\"\
                   :0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
                   ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
-                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
-                  addressAlias\":null}"
+                  :\"101동 202호\",\"shippingFee\":3000,\"orderNote\":null,\"isAddToAddressBook\"\
+                  :false,\"isDefaultAddress\":false,\"addressAlias\":null}"
               order/prepare-point-exceeds:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
                   :99999,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
                   ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
-                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
-                  addressAlias\":null}"
+                  :\"101동 202호\",\"shippingFee\":3000,\"orderNote\":null,\"isAddToAddressBook\"\
+                  :false,\"isDefaultAddress\":false,\"addressAlias\":null}"
               order/prepare-success:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
                   :0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
                   ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
-                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
-                  addressAlias\":null}"
+                  :\"101동 202호\",\"shippingFee\":3000,\"orderNote\":null,\"isAddToAddressBook\"\
+                  :false,\"isDefaultAddress\":false,\"addressAlias\":null}"
               order/prepare-success-free-shipping:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":2}],\"usedPoint\"\
                   :0,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
                   ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
-                  :\"101동 202호\",\"shippingFee\":0,\"isAddToAddressBook\":false,\"\
-                  addressAlias\":null}"
+                  :\"101동 202호\",\"shippingFee\":0,\"orderNote\":null,\"isAddToAddressBook\"\
+                  :false,\"isDefaultAddress\":false,\"addressAlias\":null}"
               order/prepare-success-with-point:
                 value: "{\"items\":[{\"productDetailId\":1,\"quantity\":1}],\"usedPoint\"\
                   :3000,\"receiver\":\"홍길동\",\"receiverPhoneNumber\":\"01012345678\"\
                   ,\"zipCode\":\"06123\",\"address\":\"서울시 강남구 테헤란로 1\",\"detailAddress\"\
-                  :\"101동 202호\",\"shippingFee\":3000,\"isAddToAddressBook\":false,\"\
-                  addressAlias\":null}"
+                  :\"101동 202호\",\"shippingFee\":3000,\"orderNote\":null,\"isAddToAddressBook\"\
+                  :false,\"isDefaultAddress\":false,\"addressAlias\":null}"
       responses:
         "400":
           description: "400"
@@ -1943,7 +1944,7 @@ paths:
                 product/product-review-stats:
                   value: "{\"success\":true,\"status\":200,\"message\":\"리뷰 통계 조회에\
                     \ 성공하였습니다.\",\"data\":{\"totalCount\":15,\"averageRating\":4.3,\"\
-                    ratingCounts\":{\"3\":2,\"4\":5,\"5\":7,\"1\":0,\"2\":1}}}"
+                    ratingCounts\":{\"1\":0,\"2\":1,\"3\":2,\"4\":5,\"5\":7}}}"
 components:
   schemas:
     ErrorResponse:
@@ -2439,48 +2440,6 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
-    v1-orders-prepare-789949242:
-      type: object
-      properties:
-        usedPoint:
-          type: number
-          description: 사용 포인트 (결제 금액에서 차감)
-        zipCode:
-          type: string
-          description: 우편번호
-        address:
-          type: string
-          description: 기본 주소
-        shippingFee:
-          type: number
-          description: 배송비
-        receiver:
-          type: string
-          description: 수령인 이름
-        receiverPhoneNumber:
-          type: string
-          description: 수령인 연락처
-        detailAddress:
-          type: string
-          description: 상세 주소
-        addressAlias:
-          type: string
-          description: "주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)"
-        items:
-          type: array
-          description: 주문 상품 목록
-          items:
-            type: object
-            properties:
-              quantity:
-                type: number
-                description: 주문 수량
-              productDetailId:
-                type: number
-                description: 상품 상세 ID
-        isAddToAddressBook:
-          type: boolean
-          description: 주소록 추가 여부
     OrderListResponse:
       title: OrderListResponse
       type: object
@@ -2923,6 +2882,54 @@ components:
         status:
           type: number
           description: HTTP 상태 코드
+    v1-orders-prepare-1990526072:
+      type: object
+      properties:
+        usedPoint:
+          type: number
+          description: 사용 포인트 (결제 금액에서 차감)
+        zipCode:
+          type: string
+          description: 우편번호
+        address:
+          type: string
+          description: 기본 주소
+        shippingFee:
+          type: number
+          description: 배송비
+        receiver:
+          type: string
+          description: 수령인 이름
+        orderNote:
+          type: string
+          description: "배송 요청사항 (100자 이내, 선택)"
+        receiverPhoneNumber:
+          type: string
+          description: 수령인 연락처
+        detailAddress:
+          type: string
+          description: 상세 주소
+        addressAlias:
+          type: string
+          description: "주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)"
+        isDefaultAddress:
+          type: boolean
+          description: 기본 배송지로 ���정 여부 (isAddToAddressBook=true일 때 적용)
+        items:
+          type: array
+          description: 주문 상품 목록
+          items:
+            type: object
+            properties:
+              quantity:
+                type: number
+                description: 주문 수량
+              productDetailId:
+                type: number
+                description: 상품 상세 ID
+        isAddToAddressBook:
+          type: boolean
+          description: 주소록 추가 여부
     v1-orders-orderNumber-cancel1320508390:
       type: object
       properties:

--- a/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/daebbang-api/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -456,7 +456,7 @@ paths:
               $ref: '#/components/schemas/v1-users486549215'
             examples:
               user/withdraw-user:
-                value: _csrf=QcZcqA8BoNgn5MnOMr0zetBmOO-dkoYDQDg5t_fyqiEsEtP5dKdvyW1gmeoKgfz3BZAHT7MHFY759-UuI11d0ZbLnBUfIeeb
+                value: _csrf=cV534udAK2MprtvmT_MjVz3ydCOV9mmB2cUyM39GMPCaR-TORzxG0tMkG1MEluqDed4XZgvCWRvxlV2s7PJWC0lyU5H-fteq
       responses:
         "200":
           description: "200"
@@ -1689,8 +1689,8 @@ paths:
                 user/check-login-id-blank:
                   value: "{\"success\":false,\"status\":400,\"message\":\"잘못된 입력값입\
                     니다.\",\"data\":null,\"errors\":[{\"field\":\"loginId\",\"message\"\
-                    :\"아이디는 비어있어서는 안됩니다.\"},{\"field\":\"loginId\",\"message\":\"아\
-                    이디는 4자에서 16자 사이여야 합니다.\"}]}"
+                    :\"아이디는 4자에서 16자 사이여야 합니다.\"},{\"field\":\"loginId\",\"message\"\
+                    :\"아이디는 비어있어서는 안됩니다.\"}]}"
                 user/check-login-id-invalid:
                   value: "{\"success\":false,\"status\":400,\"message\":\"잘못된 입력값입\
                     니다.\",\"data\":null,\"errors\":[{\"field\":\"loginId\",\"message\"\
@@ -1943,7 +1943,7 @@ paths:
                 product/product-review-stats:
                   value: "{\"success\":true,\"status\":200,\"message\":\"리뷰 통계 조회에\
                     \ 성공하였습니다.\",\"data\":{\"totalCount\":15,\"averageRating\":4.3,\"\
-                    ratingCounts\":{\"2\":1,\"1\":0,\"5\":7,\"4\":5,\"3\":2}}}"
+                    ratingCounts\":{\"3\":2,\"4\":5,\"5\":7,\"1\":0,\"2\":1}}}"
 components:
   schemas:
     ErrorResponse:

--- a/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/order/controller/OrderControllerTest.java
+++ b/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/order/controller/OrderControllerTest.java
@@ -92,7 +92,8 @@ class OrderControllerTest {
     void prepare_success_withShippingFee() throws Exception {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
-            0
+            0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
+            3_000, false, null
         );
         OrderPrepareResponse response = new OrderPrepareResponse("20260416-ABC1234567", 33_000);
         given(orderService.prepare(any())).willReturn(response);
@@ -123,7 +124,15 @@ class OrderControllerTest {
                         fieldWithPath("items").type(JsonFieldType.ARRAY).description("주문 상품 목록 (1개 이상)"),
                         fieldWithPath("items[].productDetailId").type(JsonFieldType.NUMBER).description("상품 상세 ID (색상/사이즈 조합)"),
                         fieldWithPath("items[].quantity").type(JsonFieldType.NUMBER).description("주문 수량 (최소 1)"),
-                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트 (0 이상)")
+                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트 (0 이상)"),
+                        fieldWithPath("receiver").type(JsonFieldType.STRING).description("수령인 이름"),
+                        fieldWithPath("receiverPhoneNumber").type(JsonFieldType.STRING).description("수령인 연락처"),
+                        fieldWithPath("zipCode").type(JsonFieldType.STRING).description("우편번호"),
+                        fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
+                        fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
+                        fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비 (산간지역 여부에 따라 프론트에서 결정; 5만원 이상 구매 시 0)"),
+                        fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록에 추가 여부 (true면 배송지 목록에 저장)"),
+                        fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (예: '회사', '집') - isAddToAddressBook=true일 때 사용, 선택")
                     )
                     .responseFields(
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
@@ -141,7 +150,8 @@ class OrderControllerTest {
     void prepare_success_freeShipping() throws Exception {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 2)),
-            0
+            0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
+            0, false, null
         );
         OrderPrepareResponse response = new OrderPrepareResponse("20260416-DEF9876543", 60_000);
         given(orderService.prepare(any())).willReturn(response);
@@ -164,7 +174,15 @@ class OrderControllerTest {
                         fieldWithPath("items").type(JsonFieldType.ARRAY).description("주문 상품 목록"),
                         fieldWithPath("items[].productDetailId").type(JsonFieldType.NUMBER).description("상품 상세 ID"),
                         fieldWithPath("items[].quantity").type(JsonFieldType.NUMBER).description("주문 수량"),
-                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트")
+                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트"),
+                        fieldWithPath("receiver").type(JsonFieldType.STRING).description("수령인 이름"),
+                        fieldWithPath("receiverPhoneNumber").type(JsonFieldType.STRING).description("수령인 연락처"),
+                        fieldWithPath("zipCode").type(JsonFieldType.STRING).description("우편번호"),
+                        fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
+                        fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
+                        fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비 (5만원 이상 구매 시 0)"),
+                        fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
@@ -182,7 +200,8 @@ class OrderControllerTest {
     void prepare_success_withPoint() throws Exception {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
-            3_000
+            3_000, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
+            3_000, false, null
         );
         OrderPrepareResponse response = new OrderPrepareResponse("20260416-GHI1357924", 30_000);
         given(orderService.prepare(any())).willReturn(response);
@@ -205,7 +224,15 @@ class OrderControllerTest {
                         fieldWithPath("items").type(JsonFieldType.ARRAY).description("주문 상품 목록"),
                         fieldWithPath("items[].productDetailId").type(JsonFieldType.NUMBER).description("상품 상세 ID"),
                         fieldWithPath("items[].quantity").type(JsonFieldType.NUMBER).description("주문 수량"),
-                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트 (결제 금액에서 차감)")
+                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트 (결제 금액에서 차감)"),
+                        fieldWithPath("receiver").type(JsonFieldType.STRING).description("수령인 이름"),
+                        fieldWithPath("receiverPhoneNumber").type(JsonFieldType.STRING).description("수령인 연락처"),
+                        fieldWithPath("zipCode").type(JsonFieldType.STRING).description("우편번호"),
+                        fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
+                        fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
+                        fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
@@ -221,7 +248,10 @@ class OrderControllerTest {
     @Test
     @DisplayName("POST /v1/orders/prepare - items 빈 배열이면 400 반환")
     void prepare_emptyItems() throws Exception {
-        OrderPrepareRequest request = new OrderPrepareRequest(List.of(), 0);
+        OrderPrepareRequest request = new OrderPrepareRequest(
+            List.of(), 0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
+            3_000, false, null
+        );
 
         mockMvc.perform(post("/v1/orders/prepare")
                 .with(authentication(authToken()))
@@ -239,7 +269,15 @@ class OrderControllerTest {
                     .responseSchema(Schema.schema("ErrorResponse"))
                     .requestFields(
                         fieldWithPath("items").type(JsonFieldType.ARRAY).description("주문 상품 목록 (비어있음 - 오류)"),
-                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트")
+                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트"),
+                        fieldWithPath("receiver").type(JsonFieldType.STRING).description("수령인 이름"),
+                        fieldWithPath("receiverPhoneNumber").type(JsonFieldType.STRING).description("수령인 연락처"),
+                        fieldWithPath("zipCode").type(JsonFieldType.STRING).description("우편번호"),
+                        fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
+                        fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
+                        fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
@@ -259,7 +297,8 @@ class OrderControllerTest {
     void prepare_invalidQuantity() throws Exception {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 0)),
-            0
+            0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
+            3_000, false, null
         );
 
         mockMvc.perform(post("/v1/orders/prepare")
@@ -280,7 +319,15 @@ class OrderControllerTest {
                         fieldWithPath("items").type(JsonFieldType.ARRAY).description("주문 상품 목록"),
                         fieldWithPath("items[].productDetailId").type(JsonFieldType.NUMBER).description("상품 상세 ID"),
                         fieldWithPath("items[].quantity").type(JsonFieldType.NUMBER).description("수량 (0 - 오류)"),
-                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트")
+                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트"),
+                        fieldWithPath("receiver").type(JsonFieldType.STRING).description("수령인 이름"),
+                        fieldWithPath("receiverPhoneNumber").type(JsonFieldType.STRING).description("수령인 연락처"),
+                        fieldWithPath("zipCode").type(JsonFieldType.STRING).description("우편번호"),
+                        fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
+                        fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
+                        fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
@@ -300,7 +347,8 @@ class OrderControllerTest {
     void prepare_negativeUsedPoint() throws Exception {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
-            -1
+            -1, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
+            3_000, false, null
         );
 
         mockMvc.perform(post("/v1/orders/prepare")
@@ -321,7 +369,15 @@ class OrderControllerTest {
                         fieldWithPath("items").type(JsonFieldType.ARRAY).description("주문 상품 목록"),
                         fieldWithPath("items[].productDetailId").type(JsonFieldType.NUMBER).description("상품 상세 ID"),
                         fieldWithPath("items[].quantity").type(JsonFieldType.NUMBER).description("수량"),
-                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트 (-1 - 오류)")
+                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트 (-1 - 오류)"),
+                        fieldWithPath("receiver").type(JsonFieldType.STRING).description("수령인 이름"),
+                        fieldWithPath("receiverPhoneNumber").type(JsonFieldType.STRING).description("수령인 연락처"),
+                        fieldWithPath("zipCode").type(JsonFieldType.STRING).description("우편번호"),
+                        fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
+                        fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
+                        fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
@@ -341,7 +397,8 @@ class OrderControllerTest {
     void prepare_outOfStock() throws Exception {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 999)),
-            0
+            0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
+            3_000, false, null
         );
         willThrow(new BusinessException(UserErrorCode.OUT_OF_STOCK))
             .given(orderService).prepare(any());
@@ -365,7 +422,15 @@ class OrderControllerTest {
                         fieldWithPath("items").type(JsonFieldType.ARRAY).description("주문 상품 목록"),
                         fieldWithPath("items[].productDetailId").type(JsonFieldType.NUMBER).description("상품 상세 ID"),
                         fieldWithPath("items[].quantity").type(JsonFieldType.NUMBER).description("수량 (재고 초과)"),
-                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트")
+                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트"),
+                        fieldWithPath("receiver").type(JsonFieldType.STRING).description("수령인 이름"),
+                        fieldWithPath("receiverPhoneNumber").type(JsonFieldType.STRING).description("수령인 연락처"),
+                        fieldWithPath("zipCode").type(JsonFieldType.STRING).description("우편번호"),
+                        fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
+                        fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
+                        fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
@@ -382,7 +447,8 @@ class OrderControllerTest {
     void prepare_stockLockFailed() throws Exception {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
-            0
+            0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
+            3_000, false, null
         );
         willThrow(new BusinessException(UserErrorCode.STOCK_LOCK_FAILED))
             .given(orderService).prepare(any());
@@ -406,7 +472,15 @@ class OrderControllerTest {
                         fieldWithPath("items").type(JsonFieldType.ARRAY).description("주문 상품 목록"),
                         fieldWithPath("items[].productDetailId").type(JsonFieldType.NUMBER).description("상품 상세 ID"),
                         fieldWithPath("items[].quantity").type(JsonFieldType.NUMBER).description("수량"),
-                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트")
+                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트"),
+                        fieldWithPath("receiver").type(JsonFieldType.STRING).description("수령인 이름"),
+                        fieldWithPath("receiverPhoneNumber").type(JsonFieldType.STRING).description("수령인 연락처"),
+                        fieldWithPath("zipCode").type(JsonFieldType.STRING).description("우편번호"),
+                        fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
+                        fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
+                        fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
@@ -423,7 +497,8 @@ class OrderControllerTest {
     void prepare_pointExceedsPayment() throws Exception {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
-            99_999
+            99_999, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
+            3_000, false, null
         );
         willThrow(new BusinessException(UserErrorCode.POINT_EXCEEDS_PAYMENT))
             .given(orderService).prepare(any());
@@ -447,7 +522,15 @@ class OrderControllerTest {
                         fieldWithPath("items").type(JsonFieldType.ARRAY).description("주문 상품 목록"),
                         fieldWithPath("items[].productDetailId").type(JsonFieldType.NUMBER).description("상품 상세 ID"),
                         fieldWithPath("items[].quantity").type(JsonFieldType.NUMBER).description("수량"),
-                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트 (결제 금액 초과)")
+                        fieldWithPath("usedPoint").type(JsonFieldType.NUMBER).description("사용 포인트 (결제 금액 초과)"),
+                        fieldWithPath("receiver").type(JsonFieldType.STRING).description("수령인 이름"),
+                        fieldWithPath("receiverPhoneNumber").type(JsonFieldType.STRING).description("수령인 연락처"),
+                        fieldWithPath("zipCode").type(JsonFieldType.STRING).description("우편번호"),
+                        fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
+                        fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
+                        fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
                         fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
@@ -464,7 +547,8 @@ class OrderControllerTest {
     void prepare_unauthorized() throws Exception {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
-            0
+            0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
+            3_000, false, null
         );
 
         mockMvc.perform(post("/v1/orders/prepare")
@@ -1151,7 +1235,7 @@ class OrderControllerTest {
             1L, "20260416-ABC1234567", OrderStatus.PAID,
             LocalDateTime.of(2026, 4, 16, 10, 0, 0),
             33_000, 2, "슬림핏 청바지", "https://cdn.daebbang.com/img/slim-jeans.jpg",
-            "골드", "M"
+            "골드", "M", 30_000, 1
         );
         Page<OrderSummaryResult> page = new PageImpl<>(List.of(summary), PageRequest.of(0, 10), 1);
         given(orderService.getOrderList(any(), any(), any(), any())).willReturn(page);
@@ -1200,6 +1284,8 @@ class OrderControllerTest {
                         fieldWithPath("data.content[].representativeImageUrl").type(JsonFieldType.STRING).description("대표 상품 이미지 URL"),
                         fieldWithPath("data.content[].representativeColor").type(JsonFieldType.STRING).description("대표 상품 색상"),
                         fieldWithPath("data.content[].representativeSize").type(JsonFieldType.STRING).description("대표 상품 사이즈"),
+                        fieldWithPath("data.content[].representativeUnitPrice").type(JsonFieldType.NUMBER).description("대표 상품 단가 (할인 적용 후)"),
+                        fieldWithPath("data.content[].representativeQuantity").type(JsonFieldType.NUMBER).description("대표 상품 주문 수량"),
                         fieldWithPath("data.pageable").type(JsonFieldType.OBJECT).description("페이지 정보"),
                         fieldWithPath("data.pageable.pageNumber").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
                         fieldWithPath("data.pageable.pageSize").type(JsonFieldType.NUMBER).description("페이지 크기"),

--- a/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/order/controller/OrderControllerTest.java
+++ b/daebbang-api/src/test/java/com/daebbang/daebbangapi/domain/order/controller/OrderControllerTest.java
@@ -93,7 +93,7 @@ class OrderControllerTest {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
             0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
-            3_000, false, null
+            3_000, null, false, false, null
         );
         OrderPrepareResponse response = new OrderPrepareResponse("20260416-ABC1234567", 33_000);
         given(orderService.prepare(any())).willReturn(response);
@@ -131,7 +131,9 @@ class OrderControllerTest {
                         fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
                         fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
                         fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비 (산간지역 여부에 따라 프론트에서 결정; 5만원 이상 구매 시 0)"),
+                        fieldWithPath("orderNote").type(JsonFieldType.STRING).optional().description("배송 요청사항 (100자 이내, 선택)"),
                         fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록에 추가 여부 (true면 배송지 목록에 저장)"),
+                        fieldWithPath("isDefaultAddress").type(JsonFieldType.BOOLEAN).description("기본 배송지로 설정 여부 (isAddToAddressBook=true일 때 적용)"),
                         fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (예: '회사', '집') - isAddToAddressBook=true일 때 사용, 선택")
                     )
                     .responseFields(
@@ -151,7 +153,7 @@ class OrderControllerTest {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 2)),
             0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
-            0, false, null
+            0, null, false, false, null
         );
         OrderPrepareResponse response = new OrderPrepareResponse("20260416-DEF9876543", 60_000);
         given(orderService.prepare(any())).willReturn(response);
@@ -181,7 +183,9 @@ class OrderControllerTest {
                         fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
                         fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
                         fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비 (5만원 이상 구매 시 0)"),
+                        fieldWithPath("orderNote").type(JsonFieldType.STRING).optional().description("배송 요청사항 (100자 이내, 선택)"),
                         fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("isDefaultAddress").type(JsonFieldType.BOOLEAN).description("기본 배송지로 ���정 여부 (isAddToAddressBook=true일 때 적용)"),
                         fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
@@ -201,7 +205,7 @@ class OrderControllerTest {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
             3_000, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
-            3_000, false, null
+            3_000, null, false, false, null
         );
         OrderPrepareResponse response = new OrderPrepareResponse("20260416-GHI1357924", 30_000);
         given(orderService.prepare(any())).willReturn(response);
@@ -231,7 +235,9 @@ class OrderControllerTest {
                         fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
                         fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
                         fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("orderNote").type(JsonFieldType.STRING).optional().description("배송 요청사항 (100자 이내, 선택)"),
                         fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("isDefaultAddress").type(JsonFieldType.BOOLEAN).description("기본 배송지로 ���정 여부 (isAddToAddressBook=true일 때 적용)"),
                         fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
@@ -250,7 +256,7 @@ class OrderControllerTest {
     void prepare_emptyItems() throws Exception {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(), 0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
-            3_000, false, null
+            3_000, null, false, false, null
         );
 
         mockMvc.perform(post("/v1/orders/prepare")
@@ -276,7 +282,9 @@ class OrderControllerTest {
                         fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
                         fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
                         fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("orderNote").type(JsonFieldType.STRING).optional().description("배송 요청사항 (100자 이내, 선택)"),
                         fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("isDefaultAddress").type(JsonFieldType.BOOLEAN).description("기본 배송지로 ���정 여부 (isAddToAddressBook=true일 때 적용)"),
                         fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
@@ -298,7 +306,7 @@ class OrderControllerTest {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 0)),
             0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
-            3_000, false, null
+            3_000, null, false, false, null
         );
 
         mockMvc.perform(post("/v1/orders/prepare")
@@ -326,7 +334,9 @@ class OrderControllerTest {
                         fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
                         fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
                         fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("orderNote").type(JsonFieldType.STRING).optional().description("배송 요청사항 (100자 이내, 선택)"),
                         fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("isDefaultAddress").type(JsonFieldType.BOOLEAN).description("기본 배송지로 ���정 여부 (isAddToAddressBook=true일 때 적용)"),
                         fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
@@ -348,7 +358,7 @@ class OrderControllerTest {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
             -1, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
-            3_000, false, null
+            3_000, null, false, false, null
         );
 
         mockMvc.perform(post("/v1/orders/prepare")
@@ -376,7 +386,9 @@ class OrderControllerTest {
                         fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
                         fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
                         fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("orderNote").type(JsonFieldType.STRING).optional().description("배송 요청사항 (100자 이내, 선택)"),
                         fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("isDefaultAddress").type(JsonFieldType.BOOLEAN).description("기본 배송지로 ���정 여부 (isAddToAddressBook=true일 때 적용)"),
                         fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
@@ -398,7 +410,7 @@ class OrderControllerTest {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 999)),
             0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
-            3_000, false, null
+            3_000, null, false, false, null
         );
         willThrow(new BusinessException(UserErrorCode.OUT_OF_STOCK))
             .given(orderService).prepare(any());
@@ -429,7 +441,9 @@ class OrderControllerTest {
                         fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
                         fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
                         fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("orderNote").type(JsonFieldType.STRING).optional().description("배송 요청사항 (100자 이내, 선택)"),
                         fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("isDefaultAddress").type(JsonFieldType.BOOLEAN).description("기본 배송지로 ���정 여부 (isAddToAddressBook=true일 때 적용)"),
                         fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
@@ -448,7 +462,7 @@ class OrderControllerTest {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
             0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
-            3_000, false, null
+            3_000, null, false, false, null
         );
         willThrow(new BusinessException(UserErrorCode.STOCK_LOCK_FAILED))
             .given(orderService).prepare(any());
@@ -479,7 +493,9 @@ class OrderControllerTest {
                         fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
                         fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
                         fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("orderNote").type(JsonFieldType.STRING).optional().description("배송 요청사항 (100자 이내, 선택)"),
                         fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("isDefaultAddress").type(JsonFieldType.BOOLEAN).description("기본 배송지로 ���정 여부 (isAddToAddressBook=true일 때 적용)"),
                         fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
@@ -498,7 +514,7 @@ class OrderControllerTest {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
             99_999, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
-            3_000, false, null
+            3_000, null, false, false, null
         );
         willThrow(new BusinessException(UserErrorCode.POINT_EXCEEDS_PAYMENT))
             .given(orderService).prepare(any());
@@ -529,7 +545,9 @@ class OrderControllerTest {
                         fieldWithPath("address").type(JsonFieldType.STRING).description("기본 주소"),
                         fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소"),
                         fieldWithPath("shippingFee").type(JsonFieldType.NUMBER).description("배송비"),
+                        fieldWithPath("orderNote").type(JsonFieldType.STRING).optional().description("배송 요청사항 (100자 이내, 선택)"),
                         fieldWithPath("isAddToAddressBook").type(JsonFieldType.BOOLEAN).description("주소록 추가 여부"),
+                        fieldWithPath("isDefaultAddress").type(JsonFieldType.BOOLEAN).description("기본 배송지로 ���정 여부 (isAddToAddressBook=true일 때 적용)"),
                         fieldWithPath("addressAlias").type(JsonFieldType.STRING).optional().description("주소록 별칭 (isAddToAddressBook=true일 때 사용, 선택)")
                     )
                     .responseFields(
@@ -548,7 +566,7 @@ class OrderControllerTest {
         OrderPrepareRequest request = new OrderPrepareRequest(
             List.of(new OrderItemRequest(1L, 1)),
             0, "홍길동", "01012345678", "06123", "서울시 강남구 테헤란로 1", "101동 202호",
-            3_000, false, null
+            3_000, null, false, false, null
         );
 
         mockMvc.perform(post("/v1/orders/prepare")

--- a/daebbang-common/src/main/java/com/daebbang/daebbangcommon/error/UserErrorCode.java
+++ b/daebbang-common/src/main/java/com/daebbang/daebbangcommon/error/UserErrorCode.java
@@ -58,6 +58,7 @@ public enum UserErrorCode implements ErrorCode {
     PAYMENT_NOT_FOUND(404, "결제 정보를 찾을 수 없습니다."),
     PAYMENT_CANCEL_FAILED(502, "결제 취소에 실패했습니다. 관리자에게 문의하세요."),
 
+    ORDER_SHIPPING_FEE_INVALID(400, "배송비가 올바르지 않습니다."),
     ORDER_CANCEL_NOT_ALLOWED(400, "취소할 수 없는 주문 상태입니다."),
     ORDER_PARTIAL_CANCEL_INVALID(400, "유효하지 않은 취소 항목입니다."),
     ORDER_DATE_RANGE_INVALID(400, "조회 시작일이 종료일보다 늦을 수 없습니다."),

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/command/OrderPrepareCommand.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/command/OrderPrepareCommand.java
@@ -12,6 +12,8 @@ public record OrderPrepareCommand(
     String address,
     String detailAddress,
     int shippingFee,
+    String orderNote,
     boolean isAddToAddressBook,
+    boolean isDefaultAddress,
     String addressAlias
 ) {}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/command/OrderPrepareCommand.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/command/OrderPrepareCommand.java
@@ -5,5 +5,13 @@ import java.util.List;
 public record OrderPrepareCommand(
     Long userId,
     List<OrderItemCommand> items,
-    int usedPoint
+    int usedPoint,
+    String receiver,
+    String receiverPhoneNumber,
+    String zipCode,
+    String address,
+    String detailAddress,
+    int shippingFee,
+    boolean isAddToAddressBook,
+    String addressAlias
 ) {}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/dto/OrderSummaryResult.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/dto/OrderSummaryResult.java
@@ -13,5 +13,7 @@ public record OrderSummaryResult(
     String representativeProductName,
     String representativeImageUrl,
     String representativeColor,
-    String representativeSize
+    String representativeSize,
+    int representativeUnitPrice,
+    int representativeQuantity
 ) {}

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
@@ -108,7 +108,8 @@ public class OrderServiceImpl implements OrderService {
 
         if (command.isAddToAddressBook()) {
             addressService.save(user, new AddressCommand(
-                command.addressAlias(), command.zipCode(), command.address(), command.detailAddress(), false
+                command.addressAlias(), command.zipCode(), command.address(), command.detailAddress(),
+                command.isDefaultAddress()
             ));
         }
 
@@ -188,6 +189,7 @@ public class OrderServiceImpl implements OrderService {
             .zipCode(command.zipCode())
             .address(command.address())
             .detailAddress(command.detailAddress())
+            .orderNote(command.orderNote())
             .build();
 
         orderSessionRedisRepository.save(orderNumber, session);

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
@@ -18,6 +18,8 @@ import com.daebbang.daebbangcore.domain.order.entity.Orders;
 import com.daebbang.daebbangcore.domain.order.entity.Payment;
 import com.daebbang.daebbangcore.domain.order.event.StockInvalidateEvent;
 import com.daebbang.daebbangcore.domain.order.repository.OrdersRepository;
+import com.daebbang.daebbangcore.domain.address.command.AddressCommand;
+import com.daebbang.daebbangcore.domain.address.service.AddressService;
 import com.daebbang.daebbangcore.domain.order.service.OrderService;
 import com.daebbang.daebbangcore.domain.order.service.PaymentService;
 import com.daebbang.daebbangcore.domain.order.service.StockCacheService;
@@ -71,6 +73,7 @@ public class OrderServiceImpl implements OrderService {
     private static final Duration CANCEL_IDEMPOTENCY_TTL = Duration.ofHours(24);
 
     private final UserService userService;
+    private final AddressService addressService;
     private final ProductDetailsService productDetailsService;
     private final OrdersRepository ordersRepository;
     private final PaymentService paymentService;
@@ -83,7 +86,6 @@ public class OrderServiceImpl implements OrderService {
     private final PlatformTransactionManager transactionManager;
     private final StringRedisTemplate stringRedisTemplate;
 
-    // read tx: 검증 단계에서 커넥션 조기 반환
     private TransactionTemplate readTx() {
         TransactionTemplate tx = new TransactionTemplate(transactionManager);
         tx.setReadOnly(true);
@@ -91,7 +93,6 @@ public class OrderServiceImpl implements OrderService {
         return tx;
     }
 
-    // write tx: Toss 호출 후 DB 반영
     private TransactionTemplate writeTx() {
         TransactionTemplate tx = new TransactionTemplate(transactionManager);
         tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
@@ -104,6 +105,12 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public OrderPrepareResponse prepare(OrderPrepareCommand command) {
         Users user = userService.getUserById(command.userId());
+
+        if (command.isAddToAddressBook()) {
+            addressService.save(user, new AddressCommand(
+                command.addressAlias(), command.zipCode(), command.address(), command.detailAddress(), false
+            ));
+        }
 
         List<OrderSessionItem> sessionItems = new ArrayList<>();
         Map<Long, Integer> decreasedStocks = new LinkedHashMap<>();
@@ -154,7 +161,11 @@ public class OrderServiceImpl implements OrderService {
         int totalSellingAmount = sessionItems.stream()
             .mapToInt(OrderSessionItem::getDiscountPrice)
             .sum();
-        int shippingFee = totalSellingAmount >= FREE_SHIPPING_THRESHOLD ? 0 : DEFAULT_SHIPPING_FEE;
+
+        int shippingFee = command.shippingFee();
+        if (totalSellingAmount >= FREE_SHIPPING_THRESHOLD && shippingFee != 0) {
+            throw new BusinessException(UserErrorCode.ORDER_SHIPPING_FEE_INVALID);
+        }
 
         if (command.usedPoint() > totalSellingAmount + shippingFee) {
             throw new BusinessException(UserErrorCode.POINT_EXCEEDS_PAYMENT);
@@ -172,6 +183,11 @@ public class OrderServiceImpl implements OrderService {
             .totalOriginalAmount(totalOriginalAmount)
             .totalSellingAmount(totalSellingAmount)
             .paymentAmount(paymentAmount)
+            .receiver(command.receiver())
+            .receiverPhoneNumber(command.receiverPhoneNumber())
+            .zipCode(command.zipCode())
+            .address(command.address())
+            .detailAddress(command.detailAddress())
             .build();
 
         orderSessionRedisRepository.save(orderNumber, session);
@@ -459,6 +475,7 @@ public class OrderServiceImpl implements OrderService {
         List<OrderDetails> details = order.getOrderList();
         OrderDetails first = details.isEmpty() ? null : details.get(0);
         int totalQuantity = details.stream().mapToInt(OrderDetails::getQuantity).sum();
+        int representativeUnitPrice = first != null ? first.getDiscountPrice() / first.getQuantity() : 0;
 
         return new OrderSummaryResult(
             order.getId(),
@@ -470,7 +487,9 @@ public class OrderServiceImpl implements OrderService {
             first != null ? first.getProductDetail().getProduct().getProductName() : null,
             first != null ? first.getProductDetail().getProduct().getMainImageUrl() : null,
             first != null ? first.getProductDetail().getColor() : null,
-            first != null ? first.getProductDetail().getSize() : null
+            first != null ? first.getProductDetail().getSize() : null,
+            representativeUnitPrice,
+            first != null ? first.getQuantity() : 0
         );
     }
 

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/service/impl/OrderServiceImpl.java
@@ -475,7 +475,9 @@ public class OrderServiceImpl implements OrderService {
         List<OrderDetails> details = order.getOrderList();
         OrderDetails first = details.isEmpty() ? null : details.get(0);
         int totalQuantity = details.stream().mapToInt(OrderDetails::getQuantity).sum();
-        int representativeUnitPrice = first != null ? first.getDiscountPrice() / first.getQuantity() : 0;
+        int representativeUnitPrice = (first != null && first.getQuantity() > 0)
+            ? first.getDiscountPrice() / first.getQuantity()
+            : 0;
 
         return new OrderSummaryResult(
             order.getId(),

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/session/OrderSession.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/session/OrderSession.java
@@ -25,4 +25,5 @@ public class OrderSession {
     private String zipCode;
     private String address;
     private String detailAddress;
+    private String orderNote;
 }

--- a/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/session/OrderSession.java
+++ b/daebbang-core/src/main/java/com/daebbang/daebbangcore/domain/order/session/OrderSession.java
@@ -20,4 +20,9 @@ public class OrderSession {
     private int totalOriginalAmount;
     private int totalSellingAmount;
     private int paymentAmount;
+    private String receiver;
+    private String receiverPhoneNumber;
+    private String zipCode;
+    private String address;
+    private String detailAddress;
 }


### PR DESCRIPTION
## 💻 작업 내용
<!-- 작업한 내용을 작성해주세요. -->
1. prepare시 주소 정보 및 배송비 관련 받기
2. order 리스트 조회 시 대표 상품 가격과 갯수 응답 dto 추가
<br></br>
## 💬 추가 전달 사항
<!-- 추가로 전달할 내용이 있다면 적어주세요. -->

<br></br>
## 💁‍♂️ 관련 Issues
<!-- 관련된 이슈 번호를 작성해 주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 주문 준비 단계에서 배송지 정보(수령인, 연락처, 주소) 및 배송비 입력 추가
  * 배송지를 주소록에 저장하는 옵션 추가
  * 주문 목록에 상품의 단가와 수량 정보 표시

* **버그 수정**
  * 무료 배송 대상 주문에 대한 배송비 유효성 검사 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->